### PR TITLE
Add InsertBatch

### DIFF
--- a/txn.go
+++ b/txn.go
@@ -199,6 +199,21 @@ func (txn *Txn) Insert(table string, obj interface{}) error {
 	return nil
 }
 
+// Insert is used to add or update an objects into the given table
+func (txn *Txn) InsertBatch(table string, obj ...interface{}) error {
+	if !txn.write {
+		return fmt.Errorf("cannot insert in read-only transaction")
+	}
+
+	for _, item := range obj {
+		err := txn.Insert(table, item)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // Delete is used to delete a single object from the given table
 // This object must already exist in the table
 func (txn *Txn) Delete(table string, obj interface{}) error {
@@ -278,7 +293,7 @@ func (txn *Txn) DeleteAll(table, index string, args ...interface{}) (int, error)
 
 	// Do the deletes
 	num := 0
-	for _, obj := range(objs) {
+	for _, obj := range objs {
 		if err := txn.Delete(table, obj); err != nil {
 			return num, err
 		}

--- a/txn_test.go
+++ b/txn_test.go
@@ -361,6 +361,57 @@ func TestTxn_InsertGet_Simple(t *testing.T) {
 	checkResult(txn)
 }
 
+func TestTxn_InsertBatch(t *testing.T) {
+	db := testDB(t)
+	txn := db.Txn(true)
+
+	obj1 := &TestObject{
+		ID:  "my-cool-thing",
+		Foo: "abc",
+	}
+	obj2 := &TestObject{
+		ID:  "my-other-cool-thing",
+		Foo: "xyz",
+	}
+	obj3 := &TestObject{
+		ID:  "yet-another-cool-thing",
+		Foo: "xyb",
+	}
+
+	err := txn.InsertBatch("main", obj1, obj2, obj3)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	raw, err := txn.First("main", "foo", obj1.Foo)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if raw != obj1 {
+		t.Fatalf("bad: %#v %#v", raw, obj1)
+	}
+
+	raw, err = txn.First("main", "foo", obj2.Foo)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if raw != obj2 {
+		t.Fatalf("bad: %#v %#v", raw, obj2)
+	}
+
+	raw, err = txn.First("main", "foo", obj3.Foo)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if raw != obj3 {
+		t.Fatalf("bad: %#v %#v", raw, obj3)
+	}
+
+}
+
 func TestTxn_DeleteAll_Simple(t *testing.T) {
 	db := testDB(t)
 	txn := db.Txn(true)


### PR DESCRIPTION
Hi! I just added simple extension to the API is ```Insert Batch``` method. So, ```Insert``` allows to add single object and ```Insert Batch``` is for add multiple objects.
Part of the code:

```go
obj1 := &TestObject{
	ID:  "my-cool-thing",
	Foo: "abc",
}
obj2 := &TestObject{
	ID:  "my-other-cool-thing",
	Foo: "xyz",
}
obj3 := &TestObject{
	ID:  "yet-another-cool-thing",
	Foo: "xyb",
}

err := txn.InsertBatch("main", obj1, obj2, obj3)
if err != nil {
    panic(err)
}
```