### PR TITLE
Relations between objects

### DIFF
--- a/link.go
+++ b/link.go
@@ -1,0 +1,10 @@
+package memdb
+
+//Link is used for define relations between two objects
+type Link struct {
+	Table      string
+	Index      string
+	Arg1       interface{}
+	Arg2       interface{}
+	Attributes []string
+}

--- a/memdb.go
+++ b/memdb.go
@@ -13,6 +13,7 @@ import (
 type MemDB struct {
 	schema *DBSchema
 	root   *iradix.Tree
+	links map[string][]*Link
 
 	// There can only be a single writter at once
 	writer sync.Mutex

--- a/txn.go
+++ b/txn.go
@@ -2,6 +2,7 @@ package memdb
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 
 	"github.com/hashicorp/go-immutable-radix"
@@ -22,6 +23,7 @@ type Txn struct {
 	after   []func()
 
 	modified map[tableIndex]*iradix.Txn
+	links    map[string][]*Link
 }
 
 // readableIndex returns a transaction usable for reading the given
@@ -278,7 +280,7 @@ func (txn *Txn) DeleteAll(table, index string, args ...interface{}) (int, error)
 
 	// Do the deletes
 	num := 0
-	for _, obj := range(objs) {
+	for _, obj := range objs {
 		if err := txn.Delete(table, obj); err != nil {
 			return num, err
 		}
@@ -313,6 +315,70 @@ func (txn *Txn) First(table, index string, args ...interface{}) (interface{}, er
 	iter.SeekPrefix(val)
 	_, value, _ := iter.Next()
 	return value, nil
+}
+
+//Connect is used for linking between two objects
+func (txn *Txn) Connect(link *Link) error {
+	if link == nil {
+		return fmt.Errorf("Link object is nil")
+	}
+
+	if !txn.write {
+		return fmt.Errorf("cannot insert in read-only transaction")
+	}
+
+	if link.Table == "" {
+		return fmt.Errorf("Table field is empty")
+	}
+
+	if link.Index == "" {
+		return fmt.Errorf("Index field is empty")
+	}
+
+	if len(link.Attributes) == 0 {
+		return fmt.Errorf("Attributes field is empty")
+	}
+
+	if txn.db.links == nil {
+		txn.db.links = make(map[string][]*Link)
+	}
+
+	//range over all attributes in input and store it
+	for _, attribute := range link.Attributes {
+		addr := link.Table + "." + link.Index + "." + attribute
+		links, ok := txn.db.links[addr]
+		if !ok {
+			txn.db.links[addr] = []*Link{link}
+		} else {
+			links = append(links, link)
+			txn.db.links[addr] = links
+		}
+	}
+
+	return nil
+}
+
+//GetLinks returns objects which match 'attribute'
+func (txn *Txn) GetLinks(table, index, attribute string, obj interface{}) ([]interface{}, error) {
+	links, ok := txn.db.links[table+"."+index+"."+attribute]
+	if !ok {
+		return nil, fmt.Errorf("Attributes is not found")
+	}
+	if len(links) == 0 {
+		return nil, fmt.Errorf("Attributes is not found")
+	}
+
+	result := []interface{}{}
+	for _, link := range links {
+		if reflect.DeepEqual(link.Arg1, obj) {
+			raw, err := txn.First(table, index, link.Arg2)
+			if err != nil {
+				return nil, err
+			}
+			result = append(result, raw)
+		}
+	}
+	return result, nil
 }
 
 // getIndexValue is used to get the IndexSchema and the value

--- a/txn_test.go
+++ b/txn_test.go
@@ -515,23 +515,24 @@ func TestTxn_Connect(t *testing.T) {
 	}
 
 	//Test if some attributes is missied
-	misslink := &Link{Index: "123", Arg1: 123, Arg2: 123, Attributes: []string{"123"}}
+	misslink := &Link{Index:"123", Arg1: 123, Arg2: 123, Attributes:[]string{"123"}}
 	err = txn.Connect(misslink)
-	if err == nil {
+	if err == nil{
 		t.Fatalf("Must be error, cause Table is empty")
 	}
 
 	err = txn.Connect(&Link{
-		Table:      "main",
-		Index:      "ID",
-		Arg1:       obj1.ID,
-		Arg2:       obj2.ID,
+		Table: "main",
+		Index: "ID",
+		Arg1: obj1.ID,
+		Arg2: obj2.ID,
 		Attributes: []string{"Work"},
 	})
 
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
+
 
 }
 
@@ -567,10 +568,10 @@ func TestTxn_GetLinks(t *testing.T) {
 	}
 
 	err = txn.Connect(&Link{
-		Table:      "main",
-		Index:      "id",
-		Arg1:       obj1.ID,
-		Arg2:       obj2.ID,
+		Table: "main",
+		Index: "id",
+		Arg1: obj1.ID,
+		Arg2: obj2.ID,
 		Attributes: []string{"Work"},
 	})
 
@@ -579,10 +580,10 @@ func TestTxn_GetLinks(t *testing.T) {
 	}
 
 	err = txn.Connect(&Link{
-		Table:      "main",
-		Index:      "id",
-		Arg1:       obj1.ID,
-		Arg2:       obj3.ID,
+		Table: "main",
+		Index: "id",
+		Arg1: obj1.ID,
+		Arg2: obj3.ID,
 		Attributes: []string{"Work"},
 	})
 


### PR DESCRIPTION
I added experimental feature is linking(or relations) between objects like in graph databases. 
It can be seen lika a puppet if this feature is necessary.
Usage:
```go
    obj1 := &TestObject{
		ID:  "my-object",
		Foo: "abc",
	}
	obj2 := &TestObject{
		ID:  "my-cool-thing",
		Foo: "xyz",
	}

	obj3 := &TestObject{
		ID:  "my-other-cool-thing",
		Foo: "xyz",
	}

	err := txn.Insert("main", obj1)
	if err != nil {
		t.Fatalf("err: %v", err)
	}
	err = txn.Insert("main", obj2)
	if err != nil {
		t.Fatalf("err: %v", err)
	}
	err = txn.Insert("main", obj3)
	if err != nil {
		t.Fatalf("err: %v", err)
	}

      //Connect between to ID by attribute "Work"
	err = txn.Connect(&Link{
		Table:      "main",
		Index:      "id",
		Arg1:       obj1.ID,
		Arg2:       obj2.ID,
		Attributes: []string{"Work"},
	})

    err = txn.Connect(&Link{
		Table:      "main",
		Index:      "id",
		Arg1:       obj1.ID,
		Arg2:       obj3.ID,
		Attributes: []string{"Work"},
	})

	if err != nil {
		t.Fatalf("err: %v", err)
	}

    // Get links by attribute "Work" and ID from first objects. 
    // It must return two objects(obj2.ID and obj3.ID)
    res, errlinks := txn.GetLinks("main", "id", "Work", obj1.ID)
	if errlinks != nil {
		t.Fatalf("err: %v", errlinks)
	}
```
