### PR TITLE
Introduce the ability to find multiple object based on a common prefix

### DIFF
--- a/index.go
+++ b/index.go
@@ -121,7 +121,12 @@ func (u *UUIDFieldIndex) FromArgs(args ...interface{}) ([]byte, error) {
 	}
 	switch arg := args[0].(type) {
 	case string:
-		return u.parseString(arg)
+		if len(arg) != 36 {
+			arg = strings.Replace(arg, "-", "", -1)
+			return hex.DecodeString(arg)
+		} else {
+			return u.parseString(arg)
+		}
 	case []byte:
 		if len(arg) != 16 {
 			return nil, fmt.Errorf("byte slice must be 16 characters")

--- a/txn_test.go
+++ b/txn_test.go
@@ -151,6 +151,75 @@ func TestTxn_InsertUpdate_First_NonUnique(t *testing.T) {
 	}
 }
 
+func TestTxn_Find(t *testing.T) {
+	db := testDB(t)
+	txn := db.Txn(true)
+
+	obj := &TestObject{
+		ID:  "my-first-object",
+		Foo: "foo",
+	}
+	obj2 := &TestObject{
+		ID:  "my-cool-object",
+		Foo: "bar",
+	}
+	obj3 := &TestObject{
+		ID:  "my-cool-second-object",
+		Foo: "baz",
+	}
+	obj4 := &TestObject{
+		ID:  "my-ordinary-fourth-object",
+		Foo: "baz",
+	}
+
+	err := txn.Insert("main", obj)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	err = txn.Insert("main", obj2)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	err = txn.Insert("main", obj3)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	err = txn.Insert("main", obj4)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	raw, err := txn.Find("main", "id", "my-cool")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// there should be two objects
+	if len(raw) != 2 {
+		t.Fatalf("bad: expected two objects, got: %#v", raw)
+	}
+
+	// the objects should not be equal
+	if raw[0] == raw[1] {
+		t.Fatalf("bad: expected non-equal objects, got: %#v", raw)
+	}
+
+	for _, result := range raw {
+		if result != obj2 && result != obj3 {
+			t.Fatalf("bad: object is not expected, got: %#v", raw)
+		}
+	}
+
+	raw, err = txn.Find("main", "id", "my+")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if len(raw) != 0 {
+		t.Fatalf("bad: expected zero objects, got: %#v", raw)
+	}
+}
+
 func TestTxn_First_NonUnique_Multiple(t *testing.T) {
 	db := testDB(t)
 	txn := db.Txn(true)


### PR DESCRIPTION
This change aims to provide the necessary groundwork for https://github.com/hashicorp/nomad/issues/54. It is also related to https://github.com/hashicorp/go-immutable-radix/pull/3.

It introduces the ability to search for objects that share a common prefix. As it is implemented currently, it will only find results for prefixes that are of even length when searching for UUID's. This needs to be discussed further.