### PR TITLE
Add a conditional indexer

### DIFF
--- a/index.go
+++ b/index.go
@@ -215,7 +215,7 @@ type ConditionalIndex struct {
 type ConditionalIndexFunc func(obj interface{}) (bool, error)
 
 func (c *ConditionalIndex) FromObject(obj interface{}) (bool, []byte, error) {
-	// Call the users function
+	// Call the user's function
 	res, err := c.Conditional(obj)
 	if err != nil {
 		return false, nil, fmt.Errorf("ConditionalIndexFunc(%#v) failed: %v", obj, err)

--- a/index_test.go
+++ b/index_test.go
@@ -316,6 +316,86 @@ func TestFieldSetIndex_FromArgs(t *testing.T) {
 	}
 }
 
+var (
+	// A conditional that checks if TestObject.Bar == 42
+	conditional = func(obj interface{}) (bool, error) {
+		test, ok := obj.(*TestObject)
+		if !ok {
+			return false, fmt.Errorf("Expect only TestObj types")
+		}
+
+		if test.Bar != 42 {
+			return false, nil
+		}
+
+		return true, nil
+	}
+)
+
+func TestConditionalIndex_FromObject(t *testing.T) {
+	obj := testObj()
+	indexer := ConditionalIndex{conditional}
+	obj.Bar = 42
+	ok, val, err := indexer.FromObject(obj)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(val) != 1 || val[0] != 1 {
+		t.Fatalf("bad: %v", val)
+	}
+	if !ok {
+		t.Fatalf("should be ok")
+	}
+
+	// Change the object so it should return false.
+	obj.Bar = 2
+	ok, val, err = indexer.FromObject(obj)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(val) != 1 || val[0] != 0 {
+		t.Fatalf("bad: %v", val)
+	}
+	if !ok {
+		t.Fatalf("should be ok")
+	}
+
+	// Pass an invalid type.
+	ok, val, err = indexer.FromObject(t)
+	if err == nil {
+		t.Fatalf("expected an error when passing invalid type")
+	}
+}
+
+func TestConditionalIndex_FromArgs(t *testing.T) {
+	indexer := ConditionalIndex{conditional}
+	_, err := indexer.FromArgs()
+	if err == nil {
+		t.Fatalf("should get err")
+	}
+
+	_, err = indexer.FromArgs(42)
+	if err == nil {
+		t.Fatalf("should get err")
+	}
+
+	val, err := indexer.FromArgs(true)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(val) != 1 || val[0] != 1 {
+		t.Fatalf("bad: %v", val)
+	}
+
+	val, err = indexer.FromArgs(false)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(val) != 1 || val[0] != 0 {
+		t.Fatalf("bad: %v", val)
+	}
+}
+
 func TestCompoundIndex_FromObject(t *testing.T) {
 	obj := testObj()
 	indexer := &CompoundIndex{

--- a/index_test.go
+++ b/index_test.go
@@ -236,11 +236,11 @@ func TestFieldSetIndex_FromObject(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if len(val) != 1 || val[0] != 1 {
-		t.Fatalf("bad: %v", val)
-	}
 	if !ok {
 		t.Fatalf("should be ok")
+	}
+	if len(val) != 1 || val[0] != 1 {
+		t.Fatalf("bad: %v", val)
 	}
 
 	emptyIndexer := FieldSetIndex{"Empty"}
@@ -248,11 +248,11 @@ func TestFieldSetIndex_FromObject(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if len(val) != 1 || val[0] != 0 {
-		t.Fatalf("bad: %v", val)
-	}
 	if !ok {
 		t.Fatalf("should be ok")
+	}
+	if len(val) != 1 || val[0] != 0 {
+		t.Fatalf("bad: %v", val)
 	}
 
 	setIndexer := FieldSetIndex{"Bar"}
@@ -279,11 +279,11 @@ func TestFieldSetIndex_FromObject(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if len(val) != 1 || val[0] != 0 {
-		t.Fatalf("bad: %v", val)
-	}
 	if !ok {
 		t.Fatalf("should be ok")
+	}
+	if len(val) != 1 || val[0] != 0 {
+		t.Fatalf("bad: %v", val)
 	}
 }
 
@@ -340,11 +340,11 @@ func TestConditionalIndex_FromObject(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if len(val) != 1 || val[0] != 1 {
-		t.Fatalf("bad: %v", val)
-	}
 	if !ok {
 		t.Fatalf("should be ok")
+	}
+	if len(val) != 1 || val[0] != 1 {
+		t.Fatalf("bad: %v", val)
 	}
 
 	// Change the object so it should return false.
@@ -353,11 +353,11 @@ func TestConditionalIndex_FromObject(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if len(val) != 1 || val[0] != 0 {
-		t.Fatalf("bad: %v", val)
-	}
 	if !ok {
 		t.Fatalf("should be ok")
+	}
+	if len(val) != 1 || val[0] != 0 {
+		t.Fatalf("bad: %v", val)
 	}
 
 	// Pass an invalid type.


### PR DESCRIPTION
Add a conditional indexer that lets a user specify a function that returns true or false based on the passed object and create an arbitrarily complex index.