### PR TITLE
Make UUIDFieldIndex support prefix lookups

### DIFF
--- a/index.go
+++ b/index.go
@@ -133,6 +133,21 @@ func (u *UUIDFieldIndex) FromArgs(args ...interface{}) ([]byte, error) {
 	}
 }
 
+func (u *UUIDFieldIndex) PrefixFromArgs(args ...interface{}) ([]byte, error) {
+	if len(args) != 1 {
+		return nil, fmt.Errorf("must provide only a single argument")
+	}
+	switch arg := args[0].(type) {
+	case string:
+		return u.parsePartialString(arg)
+	case []byte:
+		return arg, nil
+	default:
+		return nil,
+			fmt.Errorf("argument must be a string or byte slice: %#v", args[0])
+	}
+}
+
 func (u *UUIDFieldIndex) parseString(s string) ([]byte, error) {
 	// Verify the length
 	if len(s) != 36 {
@@ -172,6 +187,49 @@ func (u *UUIDFieldIndex) parseString(s string) ([]byte, error) {
 	copy(buf[6:8], part3)
 	copy(buf[8:10], part4)
 	copy(buf[10:16], part5)
+	return buf, nil
+}
+
+// parsePartialString parses a partial UUID from the string and returns its
+// value as a byte.
+func (u *UUIDFieldIndex) parsePartialString(s string) ([]byte, error) {
+	inputLength := len(s)
+	if inputLength == 0 {
+		return []byte{}, nil
+	}
+
+	parts := strings.Split(s, "-")
+	partsLength := len(parts)
+	if partsLength > 5 {
+		return nil, fmt.Errorf(`UUID should only have 4 "-" seperators`)
+	}
+
+	// Create the buffer. The sanatized length is the length of the original string
+	// without the "-" and the potentially necessary padding to make the input
+	// even.
+	sanatizedLength := inputLength - partsLength + 1 + (inputLength % 2)
+	buf := make([]byte, hex.DecodedLen(sanatizedLength))
+
+	// Decode each of the parts
+	index := 0
+	for _, part := range parts {
+		// Have to make the string even length. We append the 0 to the end
+		// because each part of full length UUID is even. Thus if we are at an
+		// odd length, there would be a next character to fill the lower order
+		// part of the byte. We are essentially creating the mask (pair & 0xf0)
+		if len(part)%2 == 1 {
+			part = part + "0"
+		}
+
+		dec, err := hex.DecodeString(part)
+		if err != nil {
+			return nil, fmt.Errorf("Invalid UUID: %v", err)
+		}
+		partLength := len(dec)
+		copy(buf[index:index+partLength], dec)
+		index += partLength
+	}
+
 	return buf, nil
 }
 

--- a/index_test.go
+++ b/index_test.go
@@ -183,37 +183,8 @@ func TestUUIDFeldIndex_parsePartialString(t *testing.T) {
 	// Parse an odd length UUID.
 	input := "f23"
 	out, err = u.parsePartialString(input)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
-	expected = []byte{0xf2, 0x30}
-	if !bytes.Equal(out, expected) {
-		t.Fatalf("bad: %#v %#v", out, expected)
-	}
-
-	// Parse an even length UUID.
-	input = "f23a"
-	out, err = u.parsePartialString(input)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
-	expected = []byte{0xf2, 0x3a}
-	if !bytes.Equal(out, expected) {
-		t.Fatalf("bad: %#v %#v", out, expected)
-	}
-
-	// Parse an odd length UUID with hyphen.
-	input = "6cd8d1df-"
-	out, err = u.parsePartialString(input)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
-	expected = []byte{0x6c, 0xd8, 0xd1, 0xdf}
-	if !bytes.Equal(out, expected) {
-		t.Fatalf("bad: %#v %#v", out, expected)
+	if err == nil {
+		t.Fatalf("expect error")
 	}
 
 	// Parse an even length UUID with hyphen.
@@ -355,7 +326,7 @@ func BenchmarkUUIDFieldIndex_parseString(b *testing.B) {
 	}
 }
 
-func BenchmarkUUIDFieldIndex_parseString2(b *testing.B) {
+func BenchmarkUUIDFieldIndex_parsePartialString(b *testing.B) {
 	_, uuid := generateUUID()
 	indexer := &UUIDFieldIndex{}
 	for i := 0; i < b.N; i++ {

--- a/integ_test.go
+++ b/integ_test.go
@@ -149,6 +149,12 @@ func TestComplexDB(t *testing.T) {
 		t.Fatalf("should get person")
 	}
 
+	raw, err = txn.First("people", "id_prefix", raw.(*TestPerson).ID[:4])
+	noErr(t, err)
+	if raw == nil {
+		t.Fatalf("should get person")
+	}
+
 	// Get based on field set.
 	result, err := txn.Get("people", "sibling", true)
 	noErr(t, err)


### PR DESCRIPTION
Make UUIDFieldIndexer support prefix lookups. `UUIDFieldIndex parseString` was not updated to support partial matching do to the performance implications of doing so. 