### PR TITLE
Adds support for calling the prefix method on the last sub-index for a compound index.

### DIFF
--- a/index.go
+++ b/index.go
@@ -291,10 +291,6 @@ func (c *CompoundIndex) FromArgs(args ...interface{}) ([]byte, error) {
 	if len(args) != len(c.Indexes) {
 		return nil, fmt.Errorf("less arguments than index fields")
 	}
-	return c.PrefixFromArgs(args...)
-}
-
-func (c *CompoundIndex) PrefixFromArgs(args ...interface{}) ([]byte, error) {
 	var out []byte
 	for i, arg := range args {
 		val, err := c.Indexes[i].FromArgs(arg)
@@ -302,6 +298,33 @@ func (c *CompoundIndex) PrefixFromArgs(args ...interface{}) ([]byte, error) {
 			return nil, fmt.Errorf("sub-index %d error: %v", i, err)
 		}
 		out = append(out, val...)
+	}
+	return out, nil
+}
+
+func (c *CompoundIndex) PrefixFromArgs(args ...interface{}) ([]byte, error) {
+	if len(args) > len(c.Indexes) {
+		return nil, fmt.Errorf("more arguments than index fields")
+	}
+	var out []byte
+	for i, arg := range args {
+		if i+1 < len(args) {
+			val, err := c.Indexes[i].FromArgs(arg)
+			if err != nil {
+				return nil, fmt.Errorf("sub-index %d error: %v", i, err)
+			}
+			out = append(out, val...)
+		} else {
+			prefixIndexer, ok := c.Indexes[i].(PrefixIndexer)
+			if !ok {
+				return nil, fmt.Errorf("sub-index %d does not support prefix scanning", i)
+			}
+			val, err := prefixIndexer.PrefixFromArgs(arg)
+			if err != nil {
+				return nil, fmt.Errorf("sub-index %d error: %v", i, err)
+			}
+			out = append(out, val...)
+		}
 	}
 	return out, nil
 }

--- a/index_test.go
+++ b/index_test.go
@@ -597,7 +597,23 @@ func TestCompoundIndex_PrefixFromArgs(t *testing.T) {
 	if !bytes.Equal(val[:16], uuidBuf) {
 		t.Fatalf("bad prefix")
 	}
-	if string(val[16:]) != "foo\x00" {
+	if string(val[16:]) != "foo" {
 		t.Fatalf("bad: %s", val)
+	}
+
+	val, err = indexer.PrefixFromArgs(uuid, "foo", "ba")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !bytes.Equal(val[:16], uuidBuf) {
+		t.Fatalf("bad prefix")
+	}
+	if string(val[16:]) != "foo\x00ba" {
+		t.Fatalf("bad: %s", val)
+	}
+
+	_, err = indexer.PrefixFromArgs(uuid, "foo", "bar", "nope")
+	if err == nil {
+		t.Fatalf("expected an error when passing too many arguments")
 	}
 }


### PR DESCRIPTION
This adds logic to the compound indexer to call `PrefixFromArgs()` on the last sub-indexer. Without this, we don't really get the normal prefix behavior because it calls the regular index on each sub-indexer. While we are in here we also add a check that too many arguments haven't been passed in.