### PR TITLE
Adds support for fine-grained watches.

### DIFF
--- a/integ_test.go
+++ b/integ_test.go
@@ -3,6 +3,7 @@ package memdb
 import (
 	"reflect"
 	"testing"
+	"time"
 )
 
 // Test that multiple concurrent transactions are isolated from each other
@@ -220,6 +221,44 @@ func TestComplexDB(t *testing.T) {
 	place := raw.(*TestPlace)
 	if place.Name != "Maui" {
 		t.Fatalf("bad place (but isn't anywhere else really?): %v", place)
+	}
+}
+
+func TestWatchUpdate(t *testing.T) {
+	db := testComplexDB(t)
+	testPopulateData(t, db)
+	txn := db.Txn(false) // read only
+
+	watchSetSpecific := NewWatchSet()
+	watchSetPrefix := NewWatchSet()
+
+	// Get using a full name
+	watch, raw, err := txn.FirstWatch("people", "name", "Armon", "Dadgar")
+	noErr(t, err)
+	if raw == nil {
+		t.Fatalf("should get person")
+	}
+	watchSetSpecific.Add(watch)
+
+	// Get using a prefix
+	watch, raw, err = txn.FirstWatch("people", "name_prefix", "Armon")
+	noErr(t, err)
+	if raw == nil {
+		t.Fatalf("should get person")
+	}
+	watchSetPrefix.Add(watch)
+
+	txn2 := db.Txn(true) // write
+	noErr(t, txn2.Delete("people", raw))
+	txn2.Commit()
+
+	// Both watches should trigger!
+	timeout := time.After(time.Second)
+	if timeout := watchSetSpecific.Watch(timeout); timeout {
+		t.Fatalf("should not timeout")
+	}
+	if timeout := watchSetPrefix.Watch(timeout); timeout {
+		t.Fatalf("should not timeout")
 	}
 }
 

--- a/memdb.go
+++ b/memdb.go
@@ -15,6 +15,7 @@ import (
 type MemDB struct {
 	schema *DBSchema
 	root   unsafe.Pointer // *iradix.Tree underneath
+	primary bool
 
 	// There can only be a single writter at once
 	writer sync.Mutex
@@ -31,6 +32,7 @@ func NewMemDB(schema *DBSchema) (*MemDB, error) {
 	db := &MemDB{
 		schema: schema,
 		root:   unsafe.Pointer(iradix.New()),
+		primary: true,
 	}
 	if err := db.initialize(); err != nil {
 		return nil, err
@@ -65,6 +67,7 @@ func (db *MemDB) Snapshot() *MemDB {
 	clone := &MemDB{
 		schema: db.schema,
 		root:   unsafe.Pointer(db.getRoot()),
+		primary: false,
 	}
 	return clone
 }

--- a/txn.go
+++ b/txn.go
@@ -70,11 +70,12 @@ func (txn *Txn) writableIndex(table, index string) *iradix.Txn {
 	raw, _ := txn.rootTxn.Get(path)
 	indexTxn := raw.(*iradix.Tree).Txn()
 
-	// If we are the primary DB, enable mutation notification
+	// If we are the primary DB, enable mutation tracking.
 	// Snapshots should not notify, otherwise we will trigger watches
 	// on the primary DB when the writes will not be visible.
 	if txn.db.primary {
-		indexTxn.NotifyMutate(true)
+		indexTxn.TrackMutate(true)
+		txn.Defer(indexTxn.Notify)
 	}
 
 	// Keep this open for the duration of the txn

--- a/txn.go
+++ b/txn.go
@@ -520,7 +520,7 @@ func (txn *Txn) Defer(fn func()) {
 }
 
 // radixIterator is used to wrap an underlying iradix iterator.
-// This is much mroe efficient than a sliceIterator as we are not
+// This is much more efficient than a sliceIterator as we are not
 // materializing the entire view.
 type radixIterator struct {
 	iter    *iradix.Iterator

--- a/txn.go
+++ b/txn.go
@@ -70,6 +70,13 @@ func (txn *Txn) writableIndex(table, index string) *iradix.Txn {
 	raw, _ := txn.rootTxn.Get(path)
 	indexTxn := raw.(*iradix.Tree).Txn()
 
+	// If we are the primary DB, enable mutation notification
+	// Snapshots should not notify, otherwise we will trigger watches
+	// on the primary DB when the writes will not be visible.
+	if txn.db.primary {
+		indexTxn.NotifyMutate(true)
+	}
+
 	// Keep this open for the duration of the txn
 	txn.modified[key] = indexTxn
 	return indexTxn
@@ -352,13 +359,13 @@ func (txn *Txn) DeleteAll(table, index string, args ...interface{}) (int, error)
 	return num, nil
 }
 
-// First is used to return the first matching object for
-// the given constraints on the index
-func (txn *Txn) First(table, index string, args ...interface{}) (interface{}, error) {
+// FirstWatch is used to return the first matching object for
+// the given constraints on the index along with the watch channel
+func (txn *Txn) FirstWatch(table, index string, args ...interface{}) (<-chan struct{}, interface{}, error) {
 	// Get the index value
 	indexSchema, val, err := txn.getIndexValue(table, index, args...)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Get the index itself
@@ -366,18 +373,25 @@ func (txn *Txn) First(table, index string, args ...interface{}) (interface{}, er
 
 	// Do an exact lookup
 	if indexSchema.Unique && val != nil && indexSchema.Name == index {
-		obj, ok := indexTxn.Get(val)
+		watch, obj, ok := indexTxn.GetWatch(val)
 		if !ok {
-			return nil, nil
+			return watch, nil, nil
 		}
-		return obj, nil
+		return watch, obj, nil
 	}
 
 	// Handle non-unique index by using an iterator and getting the first value
 	iter := indexTxn.Root().Iterator()
-	iter.SeekPrefix(val)
+	watch := iter.SeekPrefixWatch(val)
 	_, value, _ := iter.Next()
-	return value, nil
+	return watch, value, nil
+}
+
+// First is used to return the first matching object for
+// the given constraints on the index
+func (txn *Txn) First(table, index string, args ...interface{}) (interface{}, error) {
+	_, val, err := txn.FirstWatch(table, index, args...)
+	return val, err
 }
 
 // LongestPrefix is used to fetch the longest prefix match for the given
@@ -468,6 +482,7 @@ func (txn *Txn) getIndexValue(table, index string, args ...interface{}) (*IndexS
 // ResultIterator is used to iterate over a list of results
 // from a Get query on a table.
 type ResultIterator interface {
+	WatchCh() <-chan struct{}
 	Next() interface{}
 }
 
@@ -488,11 +503,12 @@ func (txn *Txn) Get(table, index string, args ...interface{}) (ResultIterator, e
 	indexIter := indexRoot.Iterator()
 
 	// Seek the iterator to the appropriate sub-set
-	indexIter.SeekPrefix(val)
+	watchCh := indexIter.SeekPrefixWatch(val)
 
 	// Create an iterator
 	iter := &radixIterator{
-		iter: indexIter,
+		iter:    indexIter,
+		watchCh: watchCh,
 	}
 	return iter, nil
 }
@@ -509,7 +525,12 @@ func (txn *Txn) Defer(fn func()) {
 // This is much mroe efficient than a sliceIterator as we are not
 // materializing the entire view.
 type radixIterator struct {
-	iter *iradix.Iterator
+	iter    *iradix.Iterator
+	watchCh <-chan struct{}
+}
+
+func (r *radixIterator) WatchCh() <-chan struct{} {
+	return r.watchCh
 }
 
 func (r *radixIterator) Next() interface{} {

--- a/txn.go
+++ b/txn.go
@@ -70,13 +70,10 @@ func (txn *Txn) writableIndex(table, index string) *iradix.Txn {
 	raw, _ := txn.rootTxn.Get(path)
 	indexTxn := raw.(*iradix.Tree).Txn()
 
-	// If we are the primary DB, enable mutation tracking.
-	// Snapshots should not notify, otherwise we will trigger watches
-	// on the primary DB when the writes will not be visible.
-	if txn.db.primary {
-		indexTxn.TrackMutate(true)
-		txn.Defer(indexTxn.Notify)
-	}
+	// If we are the primary DB, enable mutation tracking. Snapshots should
+	// not notify, otherwise we will trigger watches on the primary DB when
+	// the writes will not be visible.
+	indexTxn.TrackMutate(txn.db.primary)
 
 	// Keep this open for the duration of the txn
 	txn.modified[key] = indexTxn

--- a/watch-gen/main.go
+++ b/watch-gen/main.go
@@ -1,0 +1,64 @@
+// This tool generates the special-case code for a small number of watchers
+// which runs all the watches in a single select vs. needing to spawn a
+// goroutine for each one.
+package main
+
+import (
+	"fmt"
+	"os"
+	"text/template"
+)
+
+// aFew should be set to the number of channels to special-case for. Setting
+// this is a tradeoff for how big the slice is for the smallest watch set that
+// we see in practice vs. the number of goroutines we save when dealing with a
+// large number of watches. This was tuned with BenchmarkWatch to get setup
+// time for a watch with 1024 channels under 100 us on a 2.7 GHz Core i5.
+const aFew = 32
+
+// source is the template we use to generate the source file.
+const source = `//go:generate sh -c "go run watch-gen/main.go >watch_few.go"
+package memdb
+
+import(
+	"time"
+)
+
+// aFew gives how many watchers this function is wired to support. You must
+// always pass a full slice of this length, but unused channels can be nil.
+const aFew = {{len .}}
+
+// watchFew is used if there are only a few watchers as a performance
+// optimization.
+func watchFew(ch []<-chan struct{}, timeoutCh <-chan time.Time) bool {
+	select {
+{{range $i, $unused := .}}
+	case <-ch[{{printf "%d" $i}}]:
+		return false
+{{end}}
+	case <-timeoutCh:
+		return true
+	}
+}
+`
+
+// render prints the template to stdout.
+func render() error {
+	tmpl, err := template.New("watch").Parse(source)
+	if err != nil {
+		return err
+	}
+	if err := tmpl.Execute(os.Stdout, make([]struct{}, aFew)); err != nil {
+		return err
+	}
+	return nil
+}
+
+func main() {
+	if err := render(); err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(1)
+	} else {
+		os.Exit(0)
+	}
+}

--- a/watch.go
+++ b/watch.go
@@ -2,15 +2,15 @@ package memdb
 
 import "time"
 
-// WatchSet is a collection of watch channels
+// WatchSet is a collection of watch channels.
 type WatchSet map[<-chan struct{}]struct{}
 
-// NewWatchSet constructs a new watch set
+// NewWatchSet constructs a new watch set.
 func NewWatchSet() WatchSet {
 	return make(map[<-chan struct{}]struct{})
 }
 
-// Add appends a watchCh to the WatchSet if non-nil
+// Add appends a watchCh to the WatchSet if non-nil.
 func (w WatchSet) Add(watchCh <-chan struct{}) {
 	if w == nil {
 		return
@@ -21,90 +21,84 @@ func (w WatchSet) Add(watchCh <-chan struct{}) {
 	}
 }
 
-// Watch is used to wait for either the watch set to trigger or a timeout
-// Returns true on timeout
+// AddWithLimit appends a watchCh to the WatchSet if non-nil, and if the given
+// softLimit hasn't been exceeded. Otherwise, it will watch the given alternate
+// channel. It's expected that the altCh will be the same on many calls to this
+// function, so you will exceed the soft limit a little bit if you hit this, but
+// not by much.
+//
+// This is useful if you want to track individual items up to some limit, after
+// which you watch a higher-level channel (usually a channel from start start of
+// an iterator higher up in the radix tree) that will watch a superset of items.
+func (w WatchSet) AddWithLimit(softLimit int, watchCh <-chan struct{}, altCh <-chan struct{}) {
+	// This is safe for a nil WatchSet so we don't need to check that here.
+	if len(w) < softLimit {
+		w.Add(watchCh)
+	} else {
+		w.Add(altCh)
+	}
+}
+
+// Watch is used to wait for either the watch set to trigger or a timeout.
+// Returns true on timeout.
 func (w WatchSet) Watch(timeoutCh <-chan time.Time) bool {
 	if w == nil {
 		return false
 	}
 
-	if n := len(w); n <= 8 {
-		return w.watchFew(timeoutCh)
+	if n := len(w); n <= aFew {
+		idx := 0
+		chunk := make([]<-chan struct{}, aFew)
+		for watchCh := range w {
+			chunk[idx] = watchCh
+			idx++
+		}
+		return watchFew(chunk, timeoutCh)
 	} else {
 		return w.watchMany(timeoutCh)
 	}
 }
 
-// watchFew is used if there are only a few watchers as a performance optimization
-func (w WatchSet) watchFew(timeoutCh <-chan time.Time) bool {
-	var ch1, ch2, ch3, ch4, ch5, ch6, ch7, ch8 <-chan struct{}
-	idx := 0
-	for watchCh := range w {
-		switch idx {
-		case 0:
-			ch1 = watchCh
-		case 1:
-			ch2 = watchCh
-		case 2:
-			ch3 = watchCh
-		case 3:
-			ch4 = watchCh
-		case 4:
-			ch5 = watchCh
-		case 5:
-			ch6 = watchCh
-		case 6:
-			ch7 = watchCh
-		case 7:
-			ch8 = watchCh
-		}
-		idx++
-	}
-	select {
-	case <-ch1:
-		return false
-	case <-ch2:
-		return false
-	case <-ch3:
-		return false
-	case <-ch4:
-		return false
-	case <-ch5:
-		return false
-	case <-ch6:
-		return false
-	case <-ch7:
-		return false
-	case <-ch8:
-		return false
-	case <-timeoutCh:
-		return true
-	}
-}
-
-// watchMany is used if there are many watchers
+// watchMany is used if there are many watchers.
 func (w WatchSet) watchMany(timeoutCh <-chan time.Time) bool {
-	doneCh := make(chan struct{})
+	// Make a fake timeout channel we can feed into watchFew to cancel all
+	// the blocking goroutines.
+	doneCh := make(chan time.Time)
 	defer close(doneCh)
 
-	// Start a goroutine for each watcher
+	// Set up a goroutine for each watcher.
 	triggerCh := make(chan struct{}, 1)
-	watcher := func(ch <-chan struct{}) {
-		select {
-		case <-ch:
+	watcher := func(chunk []<-chan struct{}) {
+		if timeout := watchFew(chunk, doneCh); !timeout {
 			select {
 			case triggerCh <- struct{}{}:
 			default:
 			}
-		case <-doneCh:
-			return
 		}
 	}
+
+	// Apportion the watch channels into chunks we can feed into the
+	// watchFew helper.
+	idx := 0
+	chunk := make([]<-chan struct{}, aFew)
 	for watchCh := range w {
-		go watcher(watchCh)
+		subIdx := idx % aFew
+		chunk[subIdx] = watchCh
+		idx++
+
+		// Fire off this chunk and start a fresh one.
+		if idx%aFew == 0 {
+			go watcher(chunk)
+			chunk = make([]<-chan struct{}, aFew)
+		}
 	}
 
-	// Wait for a channel to trigger or timeout
+	// Make sure to watch any residual channels in the last chunk.
+	if idx%aFew != 0 {
+		go watcher(chunk)
+	}
+
+	// Wait for a channel to trigger or timeout.
 	select {
 	case <-triggerCh:
 		return false

--- a/watch.go
+++ b/watch.go
@@ -15,6 +15,7 @@ func (w WatchSet) Add(watchCh <-chan struct{}) {
 	if w == nil {
 		return
 	}
+
 	if _, ok := w[watchCh]; !ok {
 		w[watchCh] = struct{}{}
 	}
@@ -23,6 +24,10 @@ func (w WatchSet) Add(watchCh <-chan struct{}) {
 // Watch is used to wait for either the watch set to trigger or a timeout
 // Returns true on timeout
 func (w WatchSet) Watch(timeoutCh <-chan time.Time) bool {
+	if w == nil {
+		return false
+	}
+
 	if n := len(w); n <= 8 {
 		return w.watchFew(timeoutCh)
 	} else {

--- a/watch.go
+++ b/watch.go
@@ -1,0 +1,109 @@
+package memdb
+
+import "time"
+
+// WatchSet is a collection of watch channels
+type WatchSet map[<-chan struct{}]struct{}
+
+// NewWatchSet constructs a new watch set
+func NewWatchSet() WatchSet {
+	return make(map[<-chan struct{}]struct{})
+}
+
+// Add appends a watchCh to the WatchSet if non-nil
+func (w WatchSet) Add(watchCh <-chan struct{}) {
+	if w == nil {
+		return
+	}
+	if _, ok := w[watchCh]; !ok {
+		w[watchCh] = struct{}{}
+	}
+}
+
+// Watch is used to wait for either the watch set to trigger or a timeout
+// Returns true on timeout
+func (w WatchSet) Watch(timeoutCh <-chan time.Time) bool {
+	if n := len(w); n <= 8 {
+		return w.watchFew(timeoutCh)
+	} else {
+		return w.watchMany(timeoutCh)
+	}
+}
+
+// watchFew is used if there are only a few watchers as a performance optimization
+func (w WatchSet) watchFew(timeoutCh <-chan time.Time) bool {
+	var ch1, ch2, ch3, ch4, ch5, ch6, ch7, ch8 <-chan struct{}
+	idx := 0
+	for watchCh := range w {
+		switch idx {
+		case 0:
+			ch1 = watchCh
+		case 1:
+			ch2 = watchCh
+		case 2:
+			ch3 = watchCh
+		case 3:
+			ch4 = watchCh
+		case 4:
+			ch5 = watchCh
+		case 5:
+			ch6 = watchCh
+		case 6:
+			ch7 = watchCh
+		case 7:
+			ch8 = watchCh
+		}
+		idx++
+	}
+	select {
+	case <-ch1:
+		return false
+	case <-ch2:
+		return false
+	case <-ch3:
+		return false
+	case <-ch4:
+		return false
+	case <-ch5:
+		return false
+	case <-ch6:
+		return false
+	case <-ch7:
+		return false
+	case <-ch8:
+		return false
+	case <-timeoutCh:
+		return true
+	}
+}
+
+// watchMany is used if there are many watchers
+func (w WatchSet) watchMany(timeoutCh <-chan time.Time) bool {
+	doneCh := make(chan struct{})
+	defer close(doneCh)
+
+	// Start a goroutine for each watcher
+	triggerCh := make(chan struct{}, 1)
+	watcher := func(ch <-chan struct{}) {
+		select {
+		case <-ch:
+			select {
+			case triggerCh <- struct{}{}:
+			default:
+			}
+		case <-doneCh:
+			return
+		}
+	}
+	for watchCh := range w {
+		go watcher(watchCh)
+	}
+
+	// Wait for a channel to trigger or timeout
+	select {
+	case <-triggerCh:
+		return false
+	case <-timeoutCh:
+		return true
+	}
+}

--- a/watch_few.go
+++ b/watch_few.go
@@ -1,0 +1,116 @@
+//go:generate sh -c "go run watch-gen/main.go >watch_few.go"
+package memdb
+
+import(
+	"time"
+)
+
+// aFew gives how many watchers this function is wired to support. You must
+// always pass a full slice of this length, but unused channels can be nil.
+const aFew = 32
+
+// watchFew is used if there are only a few watchers as a performance
+// optimization.
+func watchFew(ch []<-chan struct{}, timeoutCh <-chan time.Time) bool {
+	select {
+
+	case <-ch[0]:
+		return false
+
+	case <-ch[1]:
+		return false
+
+	case <-ch[2]:
+		return false
+
+	case <-ch[3]:
+		return false
+
+	case <-ch[4]:
+		return false
+
+	case <-ch[5]:
+		return false
+
+	case <-ch[6]:
+		return false
+
+	case <-ch[7]:
+		return false
+
+	case <-ch[8]:
+		return false
+
+	case <-ch[9]:
+		return false
+
+	case <-ch[10]:
+		return false
+
+	case <-ch[11]:
+		return false
+
+	case <-ch[12]:
+		return false
+
+	case <-ch[13]:
+		return false
+
+	case <-ch[14]:
+		return false
+
+	case <-ch[15]:
+		return false
+
+	case <-ch[16]:
+		return false
+
+	case <-ch[17]:
+		return false
+
+	case <-ch[18]:
+		return false
+
+	case <-ch[19]:
+		return false
+
+	case <-ch[20]:
+		return false
+
+	case <-ch[21]:
+		return false
+
+	case <-ch[22]:
+		return false
+
+	case <-ch[23]:
+		return false
+
+	case <-ch[24]:
+		return false
+
+	case <-ch[25]:
+		return false
+
+	case <-ch[26]:
+		return false
+
+	case <-ch[27]:
+		return false
+
+	case <-ch[28]:
+		return false
+
+	case <-ch[29]:
+		return false
+
+	case <-ch[30]:
+		return false
+
+	case <-ch[31]:
+		return false
+
+	case <-timeoutCh:
+		return true
+	}
+}

--- a/watch_test.go
+++ b/watch_test.go
@@ -1,0 +1,156 @@
+package memdb
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// testWatch makes a bunch of watch channels based on the given size and fires
+// the one at the given fire index to make sure it's detected (or a timeout
+// occurs if the fire index isn't hit).
+func testWatch(size, fire int) error {
+	shouldTimeout := true
+	ws := NewWatchSet()
+	for i := 0; i < size; i++ {
+		watchCh := make(chan struct{})
+		ws.Add(watchCh)
+		if fire == i {
+			close(watchCh)
+			shouldTimeout = false
+		}
+	}
+
+	timeoutCh := make(chan time.Time)
+	doneCh := make(chan bool, 1)
+	go func() {
+		doneCh <- ws.Watch(timeoutCh)
+	}()
+
+	if shouldTimeout {
+		select {
+		case <-doneCh:
+			return fmt.Errorf("should not trigger")
+		default:
+		}
+
+		close(timeoutCh)
+		select {
+		case didTimeout := <-doneCh:
+			if !didTimeout {
+				return fmt.Errorf("should have timed out")
+			}
+		case <-time.After(10 * time.Second):
+			return fmt.Errorf("should have timed out")
+		}
+	} else {
+		select {
+		case didTimeout := <-doneCh:
+			if didTimeout {
+				return fmt.Errorf("should not have timed out")
+			}
+		case <-time.After(10 * time.Second):
+			return fmt.Errorf("should have triggered")
+		}
+		close(timeoutCh)
+	}
+	return nil
+}
+
+func TestWatch(t *testing.T) {
+	// Sweep through a bunch of chunks to hit the various cases of dividing
+	// the work into watchFew calls.
+	for size := 0; size < 3*aFew; size++ {
+		// Fire each possible channel slot.
+		for fire := 0; fire < size; fire++ {
+			if err := testWatch(size, fire); err != nil {
+				t.Fatalf("err %d %d: %v", size, fire, err)
+			}
+		}
+
+		// Run a timeout case as well.
+		fire := -1
+		if err := testWatch(size, fire); err != nil {
+			t.Fatalf("err %d %d: %v", size, fire, err)
+		}
+	}
+}
+
+func TestWatch_AddWithLimit(t *testing.T) {
+	// Make sure nil doesn't crash.
+	{
+		var ws WatchSet
+		ch := make(chan struct{})
+		ws.AddWithLimit(10, ch, ch)
+	}
+
+	// Run a case where we trigger a channel that should be in
+	// there.
+	{
+		ws := NewWatchSet()
+		inCh := make(chan struct{})
+		altCh := make(chan struct{})
+		ws.AddWithLimit(1, inCh, altCh)
+
+		nopeCh := make(chan struct{})
+		ws.AddWithLimit(1, nopeCh, altCh)
+
+		close(inCh)
+		didTimeout := ws.Watch(time.After(1 * time.Second))
+		if didTimeout {
+			t.Fatalf("bad")
+		}
+	}
+
+	// Run a case where we trigger the alt channel that should have
+	// been added.
+	{
+		ws := NewWatchSet()
+		inCh := make(chan struct{})
+		altCh := make(chan struct{})
+		ws.AddWithLimit(1, inCh, altCh)
+
+		nopeCh := make(chan struct{})
+		ws.AddWithLimit(1, nopeCh, altCh)
+
+		close(altCh)
+		didTimeout := ws.Watch(time.After(1 * time.Second))
+		if didTimeout {
+			t.Fatalf("bad")
+		}
+	}
+
+	// Run a case where we trigger the nope channel that should not have
+	// been added.
+	{
+		ws := NewWatchSet()
+		inCh := make(chan struct{})
+		altCh := make(chan struct{})
+		ws.AddWithLimit(1, inCh, altCh)
+
+		nopeCh := make(chan struct{})
+		ws.AddWithLimit(1, nopeCh, altCh)
+
+		close(nopeCh)
+		didTimeout := ws.Watch(time.After(1 * time.Second))
+		if !didTimeout {
+			t.Fatalf("bad")
+		}
+	}
+}
+
+func BenchmarkWatch(b *testing.B) {
+	ws := NewWatchSet()
+	for i := 0; i < 1024; i++ {
+		watchCh := make(chan struct{})
+		ws.Add(watchCh)
+	}
+
+	timeoutCh := make(chan time.Time)
+	close(timeoutCh)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ws.Watch(timeoutCh)
+	}
+}


### PR DESCRIPTION
This integrates https://github.com/hashicorp/go-immutable-radix/pull/9 into go-memdb to allow for fine-grained watches based on memdb indexes.