### PR TITLE
Fix buffer size when encoding uint fields

### DIFF
--- a/index.go
+++ b/index.go
@@ -305,20 +305,19 @@ func (u *UintFieldIndex) FromArgs(args ...interface{}) ([]byte, error) {
 }
 
 // IsUintType returns whether the passed type is a type of uint and the number
-// of bytes the type is. To avoid platform specific sizes, the uint type returns
-// 8 bytes regardless of if it is smaller.
+// of bytes needed to encode the type.
 func IsUintType(k reflect.Kind) (size int, okay bool) {
 	switch k {
 	case reflect.Uint:
-		return 8, true
+		return binary.MaxVarintLen64, true
 	case reflect.Uint8:
-		return 1, true
-	case reflect.Uint16:
 		return 2, true
+	case reflect.Uint16:
+		return binary.MaxVarintLen16, true
 	case reflect.Uint32:
-		return 4, true
+		return binary.MaxVarintLen32, true
 	case reflect.Uint64:
-		return 8, true
+		return binary.MaxVarintLen64, true
 	default:
 		return 0, false
 	}

--- a/index_test.go
+++ b/index_test.go
@@ -43,10 +43,10 @@ func testObj() *TestObject {
 			"":              "asdf",
 		},
 		Uint:   uint(1),
-		Uint8:  uint8(8),
-		Uint16: uint16(16),
-		Uint32: uint32(32),
-		Uint64: uint64(64),
+		Uint8:  uint8(1<<8 - 1),
+		Uint16: uint16(1<<16 - 1),
+		Uint32: uint32(1<<32 - 1),
+		Uint64: uint64(1<<64 - 1),
 	}
 	return obj
 }
@@ -561,11 +561,11 @@ func generateUUID() ([]byte, string) {
 func TestUintFieldIndex_FromObject(t *testing.T) {
 	obj := testObj()
 
-	euint := make([]byte, 8)
-	euint8 := make([]byte, 1)
-	euint16 := make([]byte, 2)
-	euint32 := make([]byte, 4)
-	euint64 := make([]byte, 8)
+	euint := make([]byte, 10)
+	euint8 := make([]byte, 2)
+	euint16 := make([]byte, 3)
+	euint32 := make([]byte, 5)
+	euint64 := make([]byte, 10)
 	binary.PutUvarint(euint, uint64(obj.Uint))
 	binary.PutUvarint(euint8, uint64(obj.Uint8))
 	binary.PutUvarint(euint16, uint64(obj.Uint16))
@@ -654,11 +654,11 @@ func TestUintFieldIndex_FromArgs(t *testing.T) {
 	}
 
 	obj := testObj()
-	euint := make([]byte, 8)
-	euint8 := make([]byte, 1)
-	euint16 := make([]byte, 2)
-	euint32 := make([]byte, 4)
-	euint64 := make([]byte, 8)
+	euint := make([]byte, 10)
+	euint8 := make([]byte, 2)
+	euint16 := make([]byte, 3)
+	euint32 := make([]byte, 5)
+	euint64 := make([]byte, 10)
 	binary.PutUvarint(euint, uint64(obj.Uint))
 	binary.PutUvarint(euint8, uint64(obj.Uint8))
 	binary.PutUvarint(euint16, uint64(obj.Uint16))


### PR DESCRIPTION
This PR fixes an issue where a buffer was undersized for encoding uint
fields. The encoding takes more space than the size of the uint which doesn't really make sense but... https://golang.org/pkg/encoding/binary/

Fixes https://github.com/hashicorp/go-memdb/issues/30