### PR TITLE
Add WatchCtx function

### DIFF
--- a/memdb.go
+++ b/memdb.go
@@ -76,7 +76,7 @@ func (db *MemDB) Snapshot() *MemDB {
 func (db *MemDB) initialize() error {
 	root := db.getRoot()
 	for tName, tableSchema := range db.schema.Tables {
-		for iName, _ := range tableSchema.Indexes {
+		for iName := range tableSchema.Indexes {
 			index := iradix.New()
 			path := indexPath(tName, iName)
 			root, _, _ = root.Insert(path, index)

--- a/watch-gen/main.go
+++ b/watch-gen/main.go
@@ -17,8 +17,9 @@ import (
 const aFew = 32
 
 // source is the template we use to generate the source file.
-const source = `//go:generate sh -c "go run watch-gen/main.go >watch_few.go"
-package memdb
+const source = `package memdb
+
+//go:generate sh -c "go run watch-gen/main.go >watch_few.go"
 
 import(
 	"time"
@@ -30,13 +31,13 @@ const aFew = {{len .}}
 
 // watchFew is used if there are only a few watchers as a performance
 // optimization.
-func watchFew(ch []<-chan struct{}, timeoutCh <-chan time.Time) bool {
+func watchFew(ctx context.Context, ch []<-chan struct{}) bool {
 	select {
 {{range $i, $unused := .}}
 	case <-ch[{{printf "%d" $i}}]:
 		return false
 {{end}}
-	case <-timeoutCh:
+	case <-ctx.Done():
 		return true
 	}
 }

--- a/watch.go
+++ b/watch.go
@@ -1,6 +1,9 @@
 package memdb
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
 // WatchSet is a collection of watch channels.
 type WatchSet map[<-chan struct{}]struct{}
@@ -46,6 +49,30 @@ func (w WatchSet) Watch(timeoutCh <-chan time.Time) bool {
 		return false
 	}
 
+	// Create a context that gets cancelled when the timeout is triggered
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		select {
+		case <-timeoutCh:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+
+	return w.WatchCtx(ctx)
+}
+
+// WatchCtx is used to wait for either the watch set to trigger or for the
+// context to be cancelled. Returns true if the context is cancelled. Watch with
+// a timeout channel can be mimicked by creating a context with a deadline.
+// WatchCtx should be preferred over Watch.
+func (w WatchSet) WatchCtx(ctx context.Context) bool {
+	if w == nil {
+		return false
+	}
+
 	if n := len(w); n <= aFew {
 		idx := 0
 		chunk := make([]<-chan struct{}, aFew)
@@ -53,23 +80,18 @@ func (w WatchSet) Watch(timeoutCh <-chan time.Time) bool {
 			chunk[idx] = watchCh
 			idx++
 		}
-		return watchFew(chunk, timeoutCh)
-	} else {
-		return w.watchMany(timeoutCh)
+		return watchFew(ctx, chunk)
 	}
+
+	return w.watchMany(ctx)
 }
 
 // watchMany is used if there are many watchers.
-func (w WatchSet) watchMany(timeoutCh <-chan time.Time) bool {
-	// Make a fake timeout channel we can feed into watchFew to cancel all
-	// the blocking goroutines.
-	doneCh := make(chan time.Time)
-	defer close(doneCh)
-
+func (w WatchSet) watchMany(ctx context.Context) bool {
 	// Set up a goroutine for each watcher.
 	triggerCh := make(chan struct{}, 1)
 	watcher := func(chunk []<-chan struct{}) {
-		if timeout := watchFew(chunk, doneCh); !timeout {
+		if timeout := watchFew(ctx, chunk); !timeout {
 			select {
 			case triggerCh <- struct{}{}:
 			default:
@@ -102,7 +124,7 @@ func (w WatchSet) watchMany(timeoutCh <-chan time.Time) bool {
 	select {
 	case <-triggerCh:
 		return false
-	case <-timeoutCh:
+	case <-ctx.Done():
 		return true
 	}
 }

--- a/watch_few.go
+++ b/watch_few.go
@@ -1,7 +1,10 @@
-//go:generate sh -c "go run watch-gen/main.go >watch_few.go"
 package memdb
 
-import "context"
+//go:generate sh -c "go run watch-gen/main.go >watch_few.go"
+
+import(
+	"time"
+)
 
 // aFew gives how many watchers this function is wired to support. You must
 // always pass a full slice of this length, but unused channels can be nil.

--- a/watch_few.go
+++ b/watch_few.go
@@ -1,9 +1,7 @@
 //go:generate sh -c "go run watch-gen/main.go >watch_few.go"
 package memdb
 
-import(
-	"time"
-)
+import "context"
 
 // aFew gives how many watchers this function is wired to support. You must
 // always pass a full slice of this length, but unused channels can be nil.
@@ -11,7 +9,7 @@ const aFew = 32
 
 // watchFew is used if there are only a few watchers as a performance
 // optimization.
-func watchFew(ch []<-chan struct{}, timeoutCh <-chan time.Time) bool {
+func watchFew(ctx context.Context, ch []<-chan struct{}) bool {
 	select {
 
 	case <-ch[0]:
@@ -110,7 +108,7 @@ func watchFew(ch []<-chan struct{}, timeoutCh <-chan time.Time) bool {
 	case <-ch[31]:
 		return false
 
-	case <-timeoutCh:
+	case <-ctx.Done():
 		return true
 	}
 }

--- a/watch_test.go
+++ b/watch_test.go
@@ -1,6 +1,7 @@
 package memdb
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -8,8 +9,9 @@ import (
 
 // testWatch makes a bunch of watch channels based on the given size and fires
 // the one at the given fire index to make sure it's detected (or a timeout
-// occurs if the fire index isn't hit).
-func testWatch(size, fire int) error {
+// occurs if the fire index isn't hit). useCtx parameterizes whether the context
+// based watch is used or timer based.
+func testWatch(size, fire int, useCtx bool) error {
 	shouldTimeout := true
 	ws := NewWatchSet()
 	for i := 0; i < size; i++ {
@@ -21,10 +23,22 @@ func testWatch(size, fire int) error {
 		}
 	}
 
-	timeoutCh := make(chan time.Time)
+	var timeoutCh chan time.Time
+	var ctx context.Context
+	var cancelFn context.CancelFunc
+	if useCtx {
+		ctx, cancelFn = context.WithCancel(context.Background())
+	} else {
+		timeoutCh = make(chan time.Time)
+	}
+
 	doneCh := make(chan bool, 1)
 	go func() {
-		doneCh <- ws.Watch(timeoutCh)
+		if useCtx {
+			doneCh <- ws.WatchCtx(ctx)
+		} else {
+			doneCh <- ws.Watch(timeoutCh)
+		}
 	}()
 
 	if shouldTimeout {
@@ -34,7 +48,11 @@ func testWatch(size, fire int) error {
 		default:
 		}
 
-		close(timeoutCh)
+		if useCtx {
+			cancelFn()
+		} else {
+			close(timeoutCh)
+		}
 		select {
 		case didTimeout := <-doneCh:
 			if !didTimeout {
@@ -52,28 +70,39 @@ func testWatch(size, fire int) error {
 		case <-time.After(10 * time.Second):
 			return fmt.Errorf("should have triggered")
 		}
-		close(timeoutCh)
+		if useCtx {
+			cancelFn()
+		} else {
+			close(timeoutCh)
+		}
 	}
 	return nil
 }
 
 func TestWatch(t *testing.T) {
-	// Sweep through a bunch of chunks to hit the various cases of dividing
-	// the work into watchFew calls.
-	for size := 0; size < 3*aFew; size++ {
-		// Fire each possible channel slot.
-		for fire := 0; fire < size; fire++ {
-			if err := testWatch(size, fire); err != nil {
-				t.Fatalf("err %d %d: %v", size, fire, err)
+	testFactory := func(useCtx bool) func(t *testing.T) {
+		return func(t *testing.T) {
+			// Sweep through a bunch of chunks to hit the various cases of dividing
+			// the work into watchFew calls.
+			for size := 0; size < 3*aFew; size++ {
+				// Fire each possible channel slot.
+				for fire := 0; fire < size; fire++ {
+					if err := testWatch(size, fire, useCtx); err != nil {
+						t.Fatalf("err %d %d: %v", size, fire, err)
+					}
+				}
+
+				// Run a timeout case as well.
+				fire := -1
+				if err := testWatch(size, fire, useCtx); err != nil {
+					t.Fatalf("err %d %d: %v", size, fire, err)
+				}
 			}
 		}
-
-		// Run a timeout case as well.
-		fire := -1
-		if err := testWatch(size, fire); err != nil {
-			t.Fatalf("err %d %d: %v", size, fire, err)
-		}
 	}
+
+	t.Run("Timer", testFactory(false))
+	t.Run("Context", testFactory(true))
 }
 
 func TestWatch_AddWithLimit(t *testing.T) {


### PR DESCRIPTION
This PR adds a Watch method that takes a context rather than a timeout
channel. Moving forward, the new method is the preferred as it avoids
creating a go routine.