### PR TITLE
WatchCtx returns error

### DIFF
--- a/watch-gen/main.go
+++ b/watch-gen/main.go
@@ -31,14 +31,14 @@ const aFew = {{len .}}
 
 // watchFew is used if there are only a few watchers as a performance
 // optimization.
-func watchFew(ctx context.Context, ch []<-chan struct{}) bool {
+func watchFew(ctx context.Context, ch []<-chan struct{}) error {
 	select {
 {{range $i, $unused := .}}
 	case <-ch[{{printf "%d" $i}}]:
-		return false
+		return nil
 {{end}}
 	case <-ctx.Done():
-		return true
+		return ctx.Err()
 	}
 }
 `

--- a/watch_few.go
+++ b/watch_few.go
@@ -12,106 +12,106 @@ const aFew = 32
 
 // watchFew is used if there are only a few watchers as a performance
 // optimization.
-func watchFew(ctx context.Context, ch []<-chan struct{}) bool {
+func watchFew(ctx context.Context, ch []<-chan struct{}) error {
 	select {
 
 	case <-ch[0]:
-		return false
+		return nil
 
 	case <-ch[1]:
-		return false
+		return nil
 
 	case <-ch[2]:
-		return false
+		return nil
 
 	case <-ch[3]:
-		return false
+		return nil
 
 	case <-ch[4]:
-		return false
+		return nil
 
 	case <-ch[5]:
-		return false
+		return nil
 
 	case <-ch[6]:
-		return false
+		return nil
 
 	case <-ch[7]:
-		return false
+		return nil
 
 	case <-ch[8]:
-		return false
+		return nil
 
 	case <-ch[9]:
-		return false
+		return nil
 
 	case <-ch[10]:
-		return false
+		return nil
 
 	case <-ch[11]:
-		return false
+		return nil
 
 	case <-ch[12]:
-		return false
+		return nil
 
 	case <-ch[13]:
-		return false
+		return nil
 
 	case <-ch[14]:
-		return false
+		return nil
 
 	case <-ch[15]:
-		return false
+		return nil
 
 	case <-ch[16]:
-		return false
+		return nil
 
 	case <-ch[17]:
-		return false
+		return nil
 
 	case <-ch[18]:
-		return false
+		return nil
 
 	case <-ch[19]:
-		return false
+		return nil
 
 	case <-ch[20]:
-		return false
+		return nil
 
 	case <-ch[21]:
-		return false
+		return nil
 
 	case <-ch[22]:
-		return false
+		return nil
 
 	case <-ch[23]:
-		return false
+		return nil
 
 	case <-ch[24]:
-		return false
+		return nil
 
 	case <-ch[25]:
-		return false
+		return nil
 
 	case <-ch[26]:
-		return false
+		return nil
 
 	case <-ch[27]:
-		return false
+		return nil
 
 	case <-ch[28]:
-		return false
+		return nil
 
 	case <-ch[29]:
-		return false
+		return nil
 
 	case <-ch[30]:
-		return false
+		return nil
 
 	case <-ch[31]:
-		return false
+		return nil
 
 	case <-ctx.Done():
-		return true
+		return ctx.Err()
 	}
 }

--- a/watch_test.go
+++ b/watch_test.go
@@ -35,7 +35,7 @@ func testWatch(size, fire int, useCtx bool) error {
 	doneCh := make(chan bool, 1)
 	go func() {
 		if useCtx {
-			doneCh <- ws.WatchCtx(ctx)
+			doneCh <- ws.WatchCtx(ctx) != nil
 		} else {
 			doneCh <- ws.Watch(timeoutCh)
 		}


### PR DESCRIPTION
This PR makes it so the WatchCtx method returns the error from the
context. This simplifies the use of the WatchCtx.