### PR TITLE
use ErrNotFound for deleting missing item

### DIFF
--- a/txn.go
+++ b/txn.go
@@ -14,6 +14,11 @@ const (
 	id = "id"
 )
 
+var (
+	// ErrNotFound is returned when the requested item is not found
+	ErrNotFound = fmt.Errorf("not found")
+)
+
 // tableIndex is a tuple of (Table, Index) used for lookups
 type tableIndex struct {
 	Table string
@@ -291,7 +296,7 @@ func (txn *Txn) Delete(table string, obj interface{}) error {
 	idTxn := txn.writableIndex(table, id)
 	existing, ok := idTxn.Get(idVal)
 	if !ok {
-		return fmt.Errorf("not found")
+		return ErrNotFound
 	}
 
 	// Remove the object from all the indexes

--- a/txn_test.go
+++ b/txn_test.go
@@ -390,6 +390,12 @@ func TestTxn_InsertDelete_Simple(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
+	// Delete obj1 again and expect ErrNotFound
+	err = txn.Delete("main", obj1)
+	if err != ErrNotFound {
+		t.Fatalf("expected err to be %v, got %v", ErrNotFound, err)
+	}
+
 	// Lookup of the primary obj1 should fail
 	raw, err = txn.First("main", "id", obj1.ID)
 	if err != nil {


### PR DESCRIPTION
When calling `txn.Delete` on an item that does not exist I don't want to error. Right now I am having to do `if err != nil && err.Error() == "not found"`. This change introduces and uses a new variable `ErrNotFound` so that I can use `if err == memdb.ErrNotFound`