### PR TITLE
feat: add option to enforce unique attribute

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -93,7 +93,9 @@ type IndexSchema struct {
 	// exist from a structure.
 	AllowMissing bool
 
-	Unique  bool
+	Unique            bool
+	EnforceUniqueness bool
+
 	Indexer Indexer
 }
 


### PR DESCRIPTION
Enforcing Uniqueness on an Index can go a long way since higher-level
application code doesn't need to add explicit checks for it.

To keep the change backwards compatible, changes have been made to
`Insert()` method to respect Unique constraints.

Insert will not allow update if EnforceUnique is set to true on the id
schema.
If any other schema of the table has EnforceUnique, updates using
`Insert()` will error out if the same value exists in the schema.