### PR TITLE
fix: allow nil string pointers

### DIFF
--- a/index.go
+++ b/index.go
@@ -63,10 +63,16 @@ func (s *StringFieldIndex) FromObject(obj interface{}) (bool, []byte, error) {
 	v = reflect.Indirect(v) // Dereference the pointer if any
 
 	fv := v.FieldByName(s.Field)
+	isPtr := fv.Kind() == reflect.Ptr
 	fv = reflect.Indirect(fv)
-	if !fv.IsValid() {
+	if !isPtr && !fv.IsValid() {
 		return false, nil,
-			fmt.Errorf("field '%s' for %#v is invalid", s.Field, obj)
+			fmt.Errorf("field '%s' for %#v is invalid %v ", s.Field, obj, isPtr)
+	}
+
+	if isPtr && !fv.IsValid() {
+		val := ""
+		return true, []byte(val), nil
 	}
 
 	val := fv.String()

--- a/index_test.go
+++ b/index_test.go
@@ -14,6 +14,7 @@ type TestObject struct {
 	ID       string
 	Foo      string
 	Fu       *string
+	Boo      *string
 	Bar      int
 	Baz      string
 	Bam      *bool
@@ -39,6 +40,7 @@ func testObj() *TestObject {
 		ID:  "my-cool-obj",
 		Foo: "Testing",
 		Fu:  String("Fu"),
+		Boo: nil,
 		Bar: 42,
 		Baz: "yep",
 		Bam: &b,
@@ -105,6 +107,18 @@ func TestStringFieldIndex_FromObject(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	if string(val) != "Fu\x00" {
+		t.Fatalf("bad: %s", val)
+	}
+	if !ok {
+		t.Fatalf("should be ok")
+	}
+
+	pointerField = StringFieldIndex{"Boo", false}
+	ok, val, err = pointerField.FromObject(obj)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if string(val) != "" {
 		t.Fatalf("bad: %s", val)
 	}
 	if !ok {


### PR DESCRIPTION
If a string pointer field is nil, do no return an error but an empty
value.

This helps for the cases when AllowMissing for a field is okay but we
would still like it to be indexed.