### PR TITLE
Add LowerBound to allow for index range scans

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,5 @@ module github.com/hashicorp/go-memdb
 go 1.12
 
 require github.com/hashicorp/go-immutable-radix v1.0.0
+
+replace github.com/hashicorp/go-immutable-radix => ../go-immutable-radix

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,4 @@ module github.com/hashicorp/go-memdb
 
 go 1.12
 
-require github.com/hashicorp/go-immutable-radix v1.0.0
-
-replace github.com/hashicorp/go-immutable-radix => ../go-immutable-radix
+require github.com/hashicorp/go-immutable-radix v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/hashicorp/go-immutable-radix v1.0.0 h1:AKDB1HM5PWEA7i4nhcpwOrO2byshxBjXVn/J/3+z5/0=
-github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
+github.com/hashicorp/go-immutable-radix v1.1.0 h1:vN9wG1D6KG6YHRTWr8512cxGOVgTMEfgEdSj/hr8MPc=
+github.com/hashicorp/go-immutable-radix v1.1.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-uuid v1.0.0 h1:RS8zrF7PhGwyNPOtxSClXXj9HA8feRnJzgnI1RJCSnM=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/golang-lru v0.5.0 h1:CL2msUPvZTLb5O648aiLNJw3hnBxN2+1Jq8rCOH9wdo=

--- a/txn.go
+++ b/txn.go
@@ -591,18 +591,10 @@ type ResultIterator interface {
 // Get is used to construct a ResultIterator over all the
 // rows that match the given constraints of an index.
 func (txn *Txn) Get(table, index string, args ...interface{}) (ResultIterator, error) {
-	// Get the index value to scan
-	indexSchema, val, err := txn.getIndexValue(table, index, args...)
+	indexIter, val, err := txn.getIndexIterator(table, index, args...)
 	if err != nil {
 		return nil, err
 	}
-
-	// Get the index itself
-	indexTxn := txn.readableIndex(table, indexSchema.Name)
-	indexRoot := indexTxn.Root()
-
-	// Get an interator over the index
-	indexIter := indexRoot.Iterator()
 
 	// Seek the iterator to the appropriate sub-set
 	watchCh := indexIter.SeekPrefixWatch(val)
@@ -622,18 +614,10 @@ func (txn *Txn) Get(table, index string, args ...interface{}) (ResultIterator, e
 // iterator since the radix tree doesn't efficiently allow watching on lower
 // bound changes. The WatchCh returned will be nill and so will block forever.
 func (txn *Txn) LowerBound(table, index string, args ...interface{}) (ResultIterator, error) {
-	// Get the index value to scan
-	indexSchema, val, err := txn.getIndexValue(table, index, args...)
+	indexIter, val, err := txn.getIndexIterator(table, index, args...)
 	if err != nil {
 		return nil, err
 	}
-
-	// Get the index itself
-	indexTxn := txn.readableIndex(table, indexSchema.Name)
-	indexRoot := indexTxn.Root()
-
-	// Get an interator over the index
-	indexIter := indexRoot.Iterator()
 
 	// Seek the iterator to the appropriate sub-set
 	indexIter.SeekLowerBound(val)
@@ -643,6 +627,22 @@ func (txn *Txn) LowerBound(table, index string, args ...interface{}) (ResultIter
 		iter: indexIter,
 	}
 	return iter, nil
+}
+
+func (txn *Txn) getIndexIterator(table, index string, args ...interface{}) (*iradix.Iterator, []byte, error) {
+	// Get the index value to scan
+	indexSchema, val, err := txn.getIndexValue(table, index, args...)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Get the index itself
+	indexTxn := txn.readableIndex(table, indexSchema.Name)
+	indexRoot := indexTxn.Root()
+
+	// Get an interator over the index
+	indexIter := indexRoot.Iterator()
+	return indexIter, val, nil
 }
 
 // Defer is used to push a new arbitrary function onto a stack which


### PR DESCRIPTION
This PR builds on https://github.com/hashicorp/go-immutable-radix/pull/24 to allow range scans of memdb indexes.

Lower bound seeks the iterator to the first key that is greater than or equal to some search key. The iterator can then be used to iterate in order over the rest of the values. A caller can simply stop when the result is "to high" to bound the range at the upper end.

An example use case would be using an IntFieldIndex to index over timestamps. `LowerBound` allows finding the first item with a timestamp greater or equal to the start of some time range. The returned iterator can then be iterated until the end of the range of interest.

## Limitations

Due to limitations in iradix, Iterators returned from this method can't be used to watch for changes in the lower bound or range. See https://github.com/hashicorp/go-immutable-radix/pull/24 for details on why. The `WatchCh` returned by such an iterator is nil and so will block forever.

This depends on https://github.com/hashicorp/go-immutable-radix/pull/24 landing and the `mod.go` replace will be removed before submission.