### PR TITLE
Add support for nested fields on StringFieldIndex

### DIFF
--- a/index.go
+++ b/index.go
@@ -311,6 +311,7 @@ func (s *NestedStringFieldIndex) FromObject(obj interface{}) (bool, []byte, erro
 		v = reflect.Indirect(v) // Dereference the pointer if any
 		fv = v.FieldByName(field)
 
+		// Validation checks
 		isPtr := fv.Kind() == reflect.Ptr
 		fv = reflect.Indirect(fv)
 		if !isPtr && !fv.IsValid() {

--- a/index.go
+++ b/index.go
@@ -315,7 +315,7 @@ func (s *NestedStringFieldIndex) FromObject(obj interface{}) (bool, []byte, erro
 		fv = reflect.Indirect(fv)
 		if !isPtr && !fv.IsValid() {
 			return false, nil,
-				fmt.Errorf("field '%s' for %#v is invalid %v ",
+				fmt.Errorf("field '%s' for %#v is invalid (isPtr:%v) ",
 					strings.Join(fieldTokens[:i+1], "."),
 					objPivot,
 					isPtr)

--- a/index_test.go
+++ b/index_test.go
@@ -377,6 +377,133 @@ func TestStringMapFieldIndex_FromObject(t *testing.T) {
 	}
 }
 
+func TestNestedStringFieldIndex_FromObject(t *testing.T) {
+	obj := testObj()
+	indexer := NestedStringFieldIndex{"Foo", false}
+
+	ok, val, err := indexer.FromObject(obj)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if string(val) != "Testing\x00" {
+		t.Fatalf("bad: %s", val)
+	}
+	if !ok {
+		t.Fatalf("should be ok")
+	}
+
+	lower := NestedStringFieldIndex{"Foo", true}
+	ok, val, err = lower.FromObject(obj)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if string(val) != "testing\x00" {
+		t.Fatalf("bad: %s", val)
+	}
+	if !ok {
+		t.Fatalf("should be ok")
+	}
+
+	badField := NestedStringFieldIndex{"NA", true}
+	ok, val, err = badField.FromObject(obj)
+	if err == nil {
+		t.Fatalf("should get error")
+	}
+
+	emptyField := NestedStringFieldIndex{"Empty", true}
+	ok, val, err = emptyField.FromObject(obj)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if ok {
+		t.Fatalf("should not ok")
+	}
+
+	pointerField := NestedStringFieldIndex{"Fu", false}
+	ok, val, err = pointerField.FromObject(obj)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if string(val) != "Fu\x00" {
+		t.Fatalf("bad: %s", val)
+	}
+	if !ok {
+		t.Fatalf("should be ok")
+	}
+
+	pointerField = NestedStringFieldIndex{"Boo", false}
+	ok, val, err = pointerField.FromObject(obj)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if string(val) != "" {
+		t.Fatalf("bad: %s", val)
+	}
+	if !ok {
+		t.Fatalf("should be ok")
+	}
+}
+
+func TestNestedStringFieldIndex_FromArgs(t *testing.T) {
+	indexer := NestedStringFieldIndex{"Foo", false}
+	_, err := indexer.FromArgs()
+	if err == nil {
+		t.Fatalf("should get err")
+	}
+
+	_, err = indexer.FromArgs(42)
+	if err == nil {
+		t.Fatalf("should get err")
+	}
+
+	val, err := indexer.FromArgs("foo")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if string(val) != "foo\x00" {
+		t.Fatalf("foo")
+	}
+
+	lower := NestedStringFieldIndex{"Foo", true}
+	val, err = lower.FromArgs("Foo")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if string(val) != "foo\x00" {
+		t.Fatalf("foo")
+	}
+}
+
+func TestNestedStringFieldIndex_PrefixFromArgs(t *testing.T) {
+	indexer := NestedStringFieldIndex{"Foo", false}
+	_, err := indexer.FromArgs()
+	if err == nil {
+		t.Fatalf("should get err")
+	}
+
+	_, err = indexer.PrefixFromArgs(42)
+	if err == nil {
+		t.Fatalf("should get err")
+	}
+
+	val, err := indexer.PrefixFromArgs("foo")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if string(val) != "foo" {
+		t.Fatalf("foo")
+	}
+
+	lower := NestedStringFieldIndex{"Foo", true}
+	val, err = lower.PrefixFromArgs("Foo")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if string(val) != "foo" {
+		t.Fatalf("foo")
+	}
+}
+
 func TestStringMapFieldIndex_FromArgs(t *testing.T) {
 	indexer := StringMapFieldIndex{"Zod", false}
 	_, err := indexer.FromArgs()

--- a/integ_test.go
+++ b/integ_test.go
@@ -216,6 +216,12 @@ func TestComplexDB(t *testing.T) {
 		t.Fatalf("should get person")
 	}
 
+	raw, err = txn.First("people", "sibling_name", "Alex")
+	noErr(t, err)
+	if raw == nil {
+		t.Fatalf("should get person")
+	}
+
 	person = raw.(*TestPerson)
 	if person.First != "Mitchell" {
 		t.Fatalf("wrong person!")
@@ -469,6 +475,11 @@ func testComplexSchema() *DBSchema {
 						Name:    "sibling",
 						Unique:  false,
 						Indexer: &FieldSetIndex{Field: "Sibling"},
+					},
+					"sibling_name": &IndexSchema{
+						Name:    "sibling_name",
+						Unique:  false,
+						Indexer: &NestedStringFieldIndex{Field: "Sibling.Name"},
 					},
 				},
 			},

--- a/integ_test.go
+++ b/integ_test.go
@@ -216,6 +216,11 @@ func TestComplexDB(t *testing.T) {
 		t.Fatalf("should get person")
 	}
 
+	person = raw.(*TestPerson)
+	if person.First != "Mitchell" {
+		t.Fatalf("wrong person!")
+	}
+
 	raw, err = txn.First("people", "sibling_first", "Alex")
 	noErr(t, err)
 	if raw == nil {

--- a/integ_test.go
+++ b/integ_test.go
@@ -209,6 +209,17 @@ func TestComplexDB(t *testing.T) {
 		t.Fatalf("wrong person!")
 	}
 
+	raw, err = txn.First("people", "sibling_first", "Alex")
+	noErr(t, err)
+	if raw == nil {
+		t.Fatalf("should get person")
+	}
+
+	person = raw.(*TestPerson)
+	if person.First != "Armon" {
+		t.Fatalf("wrong person!")
+	}
+
 	// Where in the world is mitchell hashimoto?
 	raw, err = txn.First("people", "name_prefix", "Mitchell")
 	noErr(t, err)
@@ -218,17 +229,6 @@ func TestComplexDB(t *testing.T) {
 
 	person = raw.(*TestPerson)
 	if person.First != "Mitchell" {
-		t.Fatalf("wrong person!")
-	}
-
-	raw, err = txn.First("people", "sibling_first", "Alex")
-	noErr(t, err)
-	if raw == nil {
-		t.Fatalf("should get person")
-	}
-
-	person = raw.(*TestPerson)
-	if person.First != "Armon" {
 		t.Fatalf("wrong person!")
 	}
 

--- a/integ_test.go
+++ b/integ_test.go
@@ -216,14 +216,14 @@ func TestComplexDB(t *testing.T) {
 		t.Fatalf("should get person")
 	}
 
-	raw, err = txn.First("people", "sibling_name", "Alex")
+	raw, err = txn.First("people", "sibling_first", "Alex")
 	noErr(t, err)
 	if raw == nil {
 		t.Fatalf("should get person")
 	}
 
 	person = raw.(*TestPerson)
-	if person.First != "Mitchell" {
+	if person.First != "Armon" {
 		t.Fatalf("wrong person!")
 	}
 
@@ -476,10 +476,10 @@ func testComplexSchema() *DBSchema {
 						Unique:  false,
 						Indexer: &FieldSetIndex{Field: "Sibling"},
 					},
-					"sibling_name": &IndexSchema{
-						Name:    "sibling_name",
+					"sibling_first": &IndexSchema{
+						Name:    "sibling_first",
 						Unique:  false,
-						Indexer: &NestedStringFieldIndex{Field: "Sibling.Name"},
+						Indexer: &NestedStringFieldIndex{Field: "Sibling.First"},
 					},
 				},
 			},


### PR DESCRIPTION
Following the examples in the integration tests, I'm talking about nested field accessors of the following form:

```go
"sibling_first": &IndexSchema{
    Name:    "sibling_first",
    Unique:  false,
    Indexer: &NestedStringFieldIndex{Field: "Sibling.First"},
},
```

Rather than including this behavior as the default in the StringFieldIndex (becasue of the performance penalty of object traversal), I added a separate index type, NestedStringFieldIndex

