### PR TITLE
Add IntSliceFieldIndex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+.idea

--- a/index.go
+++ b/index.go
@@ -452,7 +452,11 @@ func (s *IntSliceFieldIndex) FromObject(obj interface{}) (bool, [][]byte, error)
 	length := fv.Len()
 	vals := make([][]byte, 0, length)
 	for i := 0; i < fv.Len(); i++ {
-		buf := make([]byte, 4)
+		size, ok := IsIntType(fv.Index(i).Kind())
+		if !ok {
+			return false, nil, fmt.Errorf("arg is of type %v; want an int", fv.Index(i))
+		}
+		buf := make([]byte, size)
 		binary.LittleEndian.PutUint32(buf, uint32(fv.Index(i).Int()))
 		vals = append(vals, buf)
 	}
@@ -475,7 +479,7 @@ func (i *IntSliceFieldIndex) FromArgs(args ...interface{}) ([]byte, error) {
 	k := v.Kind()
 	size, ok := IsIntType(k)
 	if !ok {
-		return nil, fmt.Errorf("arg is of type %v; want a uint", k)
+		return nil, fmt.Errorf("arg is of type %v; want an int", k)
 	}
 
 	buf := make([]byte, size)

--- a/index.go
+++ b/index.go
@@ -428,6 +428,71 @@ func IsUintType(k reflect.Kind) (size int, okay bool) {
 	}
 }
 
+// IntSliceFieldIndex builds an index from a field on an object that is a
+// int slice ([]int). Each value within the int slice can be used for
+// lookup.
+type IntSliceFieldIndex struct {
+	Field string
+}
+
+func (s *IntSliceFieldIndex) FromObject(obj interface{}) (bool, [][]byte, error) {
+	v := reflect.ValueOf(obj)
+	v = reflect.Indirect(v) // Dereference the pointer if any
+
+	fv := v.FieldByName(s.Field)
+	if !fv.IsValid() {
+		return false, nil,
+			fmt.Errorf("field '%s' for %#v is invalid", s.Field, obj)
+	}
+
+	if fv.Kind() != reflect.Slice || fv.Type().Elem().Kind() != reflect.Int {
+		return false, nil, fmt.Errorf("field '%s' is not an int slice", s.Field)
+	}
+
+	length := fv.Len()
+	vals := make([][]byte, 0, length)
+	for i := 0; i < fv.Len(); i++ {
+		buf := make([]byte, 4)
+		binary.LittleEndian.PutUint32(buf, uint32(fv.Index(i).Int()))
+		vals = append(vals, buf)
+	}
+	if len(vals) == 0 {
+		return false, nil, nil
+	}
+	return true, vals, nil
+}
+
+func (i *IntSliceFieldIndex) FromArgs(args ...interface{}) ([]byte, error) {
+	if len(args) != 1 {
+		return nil, fmt.Errorf("must provide only a single argument")
+	}
+
+	v := reflect.ValueOf(args[0])
+	if !v.IsValid() {
+		return nil, fmt.Errorf("%#v is invalid", args[0])
+	}
+
+	k := v.Kind()
+	size, ok := IsIntType(k)
+	if !ok {
+		return nil, fmt.Errorf("arg is of type %v; want a uint", k)
+	}
+
+	buf := make([]byte, size)
+	val := v.Int()
+	binary.LittleEndian.PutUint32(buf, uint32(val))
+
+	return buf, nil
+}
+
+func (s *IntSliceFieldIndex) PrefixFromArgs(args ...interface{}) ([]byte, error) {
+	val, err := s.FromArgs(args...)
+	if err != nil {
+		return nil, err
+	}
+	return val, nil
+}
+
 // UUIDFieldIndex is used to extract a field from an object
 // using reflection and builds an index on that field by treating
 // it as a UUID. This is an optimization to using a StringFieldIndex

--- a/index.go
+++ b/index.go
@@ -3,6 +3,7 @@ package memdb
 import (
 	"encoding/binary"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -195,6 +196,16 @@ func (s *StringSliceFieldIndex) PrefixFromArgs(args ...interface{}) ([]byte, err
 
 // StringMapFieldIndex is used to extract a field of type map[string]string
 // from an object using reflection and builds an index on that field.
+//
+// Note that although FromArgs in theory supports using either one or
+// two arguments, there is a bug: FromObject only creates an index
+// using key/value, and does not also create an index using key. This
+// means a lookup using one argument will never actually work.
+//
+// It is currently left as-is to prevent backwards compatibility
+// issues.
+//
+// TODO: Fix this in the next major bump.
 type StringMapFieldIndex struct {
 	Field     string
 	Lowercase bool
@@ -240,6 +251,8 @@ func (s *StringMapFieldIndex) FromObject(obj interface{}) (bool, [][]byte, error
 	return true, vals, nil
 }
 
+// WARNING: Because of a bug in FromObject, this function will never return
+// a value when using the single-argument version.
 func (s *StringMapFieldIndex) FromArgs(args ...interface{}) ([]byte, error) {
 	if len(args) > 2 || len(args) == 0 {
 		return nil, fmt.Errorf("must provide one or two arguments")
@@ -620,7 +633,7 @@ func (c *CompoundIndex) FromObject(raw interface{}) (bool, []byte, error) {
 
 func (c *CompoundIndex) FromArgs(args ...interface{}) ([]byte, error) {
 	if len(args) != len(c.Indexes) {
-		return nil, fmt.Errorf("less arguments than index fields")
+		return nil, fmt.Errorf("non-equivalent argument count and index fields")
 	}
 	var out []byte
 	for i, arg := range args {
@@ -656,6 +669,180 @@ func (c *CompoundIndex) PrefixFromArgs(args ...interface{}) ([]byte, error) {
 			}
 			out = append(out, val...)
 		}
+	}
+	return out, nil
+}
+
+// CompoundMultiIndex is used to build an index using multiple
+// sub-indexes.
+//
+// Unlike CompoundIndex, CompoundMultiIndex can have both
+// SingleIndexer and MultiIndexer sub-indexers. However, each
+// MultiIndexer adds considerable overhead/complexity in terms of
+// the number of indexes created under-the-hood. It is not suggested
+// to use more than one or two, if possible.
+//
+// Another change from CompoundIndexer is that if AllowMissing is
+// set, not only is it valid to have empty index fields, but it will
+// still create index values up to the first empty index. This means
+// that if you have a value with an empty field, rather than using a
+// prefix for lookup, you can simply pass in less arguments. As an
+// example, if {Foo, Bar} is indexed but Bar is missing for a value
+// and AllowMissing is set, an index will still be created for {Foo}
+// and it is valid to do a lookup passing in only Foo as an argument.
+// Note that the ordering isn't guaranteed -- it's last-insert wins,
+// but this is true if you have two objects that have the same
+// indexes not using AllowMissing anyways.
+//
+// Because StringMapFieldIndexers can take a varying number of args,
+// it is currently a requirement that whenever it is used, two
+// arguments must _always_ be provided for it. In theory we only
+// need one, except a bug in that indexer means the single-argument
+// version will never work. You can leave the second argument nil,
+// but it will never produce a value. We support this for whenever
+// that bug is fixed, likely in a next major version bump.
+//
+// Prefix-based indexing is not currently supported.
+type CompoundMultiIndex struct {
+	Indexes []Indexer
+
+	// AllowMissing results in an index based on only the indexers
+	// that return data. If true, you may end up with 2/3 columns
+	// indexed which might be useful for an index scan. Otherwise,
+	// CompoundMultiIndex requires all indexers to be satisfied.
+	AllowMissing bool
+}
+
+func (c *CompoundMultiIndex) FromObject(raw interface{}) (bool, [][]byte, error) {
+	// At each entry, builder is storing the results from the next index
+	builder := make([][][]byte, 0, len(c.Indexes))
+	// Start with something higher to avoid resizing if possible
+	out := make([][]byte, 0, len(c.Indexes)^3)
+
+forloop:
+	// This loop goes through each indexer and adds the value(s) provided to the next
+	// entry in the slice. We can then later walk it like a tree to construct the indices.
+	for i, idxRaw := range c.Indexes {
+		switch idx := idxRaw.(type) {
+		case SingleIndexer:
+			ok, val, err := idx.FromObject(raw)
+			if err != nil {
+				return false, nil, fmt.Errorf("single sub-index %d error: %v", i, err)
+			}
+			if !ok {
+				if c.AllowMissing {
+					break forloop
+				} else {
+					return false, nil, nil
+				}
+			}
+			builder = append(builder, [][]byte{val})
+
+		case MultiIndexer:
+			ok, vals, err := idx.FromObject(raw)
+			if err != nil {
+				return false, nil, fmt.Errorf("multi sub-index %d error: %v", i, err)
+			}
+			if !ok {
+				if c.AllowMissing {
+					break forloop
+				} else {
+					return false, nil, nil
+				}
+			}
+
+			// Add each of the new values to each of the old values
+			builder = append(builder, vals)
+
+		default:
+			return false, nil, fmt.Errorf("sub-index %d does not satisfy either SingleIndexer or MultiIndexer", i)
+		}
+	}
+
+	// We are walking through the builder slice essentially in a depth-first fashion,
+	// building the prefix and leaves as we go. If AllowMissing is false, we only insert
+	// these full paths to leaves. Otherwise, we also insert each prefix along the way.
+	// This allows for lookup in FromArgs when AllowMissing is true that does not contain
+	// the full set of arguments. e.g. for {Foo, Bar} where an object has only the Foo
+	// field specified as "abc", it is valid to call FromArgs with just "abc".
+	var walkVals func([]byte, int)
+	walkVals = func(currPrefix []byte, depth int) {
+		if depth == len(builder)-1 {
+			// These are the "leaves", so append directly
+			for _, v := range builder[depth] {
+				out = append(out, append(currPrefix, v...))
+			}
+			return
+		}
+		for _, v := range builder[depth] {
+			nextPrefix := append(currPrefix, v...)
+			if c.AllowMissing {
+				out = append(out, nextPrefix)
+			}
+			walkVals(nextPrefix, depth+1)
+		}
+	}
+
+	walkVals(nil, 0)
+
+	return true, out, nil
+}
+
+func (c *CompoundMultiIndex) FromArgs(args ...interface{}) ([]byte, error) {
+	var stringMapCount int
+	var argCount int
+	for _, index := range c.Indexes {
+		if argCount >= len(args) {
+			break
+		}
+		if _, ok := index.(*StringMapFieldIndex); ok {
+			// We require pairs for StringMapFieldIndex, but only got one
+			if argCount+1 >= len(args) {
+				return nil, errors.New("invalid number of arguments")
+			}
+			stringMapCount++
+			argCount += 2
+		} else {
+			argCount++
+		}
+	}
+	argCount = 0
+
+	switch c.AllowMissing {
+	case true:
+		if len(args) > len(c.Indexes)+stringMapCount {
+			return nil, errors.New("too many arguments")
+		}
+
+	default:
+		if len(args) != len(c.Indexes)+stringMapCount {
+			return nil, errors.New("number of arguments does not equal number of indexers")
+		}
+	}
+
+	var out []byte
+	var val []byte
+	var err error
+	for i, idx := range c.Indexes {
+		if argCount >= len(args) {
+			// We're done; should only hit this if AllowMissing
+			break
+		}
+		if _, ok := idx.(*StringMapFieldIndex); ok {
+			if args[argCount+1] == nil {
+				val, err = idx.FromArgs(args[argCount])
+			} else {
+				val, err = idx.FromArgs(args[argCount : argCount+2]...)
+			}
+			argCount += 2
+		} else {
+			val, err = idx.FromArgs(args[argCount])
+			argCount++
+		}
+		if err != nil {
+			return nil, fmt.Errorf("sub-index %d error: %v", i, err)
+		}
+		out = append(out, val...)
 	}
 	return out, nil
 }

--- a/index_test.go
+++ b/index_test.go
@@ -331,7 +331,7 @@ func TestStringMapFieldIndex_FromObject(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	if len(vals) != 2 {
-		t.Fatal("bad result length")
+		t.Fatalf("bad result length of %d", len(vals))
 	}
 	if string(vals[0]) != "Role\x00Server\x00" {
 		t.Fatalf("bad: %s", vals[0])

--- a/integ_test.go
+++ b/integ_test.go
@@ -239,6 +239,46 @@ func TestComplexDB(t *testing.T) {
 	if place.Name != "Maui" {
 		t.Fatalf("bad place (but isn't anywhere else really?): %v", place)
 	}
+
+	raw, err = txn.First("places", "name_tags", "HashiCorp", "North America")
+	noErr(t, err)
+	if raw == nil {
+		t.Fatalf("should get place")
+	}
+	place = raw.(*TestPlace)
+	if place.Name != "HashiCorp" {
+		t.Fatalf("bad place (but isn't anywhere else really?): %v", place)
+	}
+
+	raw, err = txn.First("places", "name_tags", "Maui")
+	noErr(t, err)
+	if raw == nil {
+		t.Fatalf("should get place")
+	}
+	place = raw.(*TestPlace)
+	if place.Name != "Maui" {
+		t.Fatalf("bad place (but isn't anywhere else really?): %v", place)
+	}
+
+	raw, err = txn.First("places", "name_tags_name_meta", "HashiCorp", "North America", "HashiCorp", "Food", "Pretty Good")
+	noErr(t, err)
+	if raw == nil {
+		t.Fatalf("should get place")
+	}
+	place = raw.(*TestPlace)
+	if place.Tags[1] != "USA" {
+		t.Fatalf("bad place: %v", place)
+	}
+
+	raw, err = txn.First("places", "name_tags_name_meta", "HashiCorp", "North America", "HashiCorp", "Piers", "Pretty Salty")
+	noErr(t, err)
+	if raw == nil {
+		t.Fatalf("should get place")
+	}
+	place = raw.(*TestPlace)
+	if place.Tags[1] != "Earth" {
+		t.Fatalf("bad place: %v", place)
+	}
 }
 
 func TestWatchUpdate(t *testing.T) {
@@ -334,8 +374,13 @@ func testPopulateData(t *testing.T, db *MemDB) {
 	person3.Sibling = person1
 
 	place1 := testPlace()
+	place1.Tags = []string{"North America", "USA"}
+	place1.Meta = map[string]string{"Food": "Pretty Good"}
 	place2 := testPlace()
 	place2.Name = "Maui"
+	place3 := testPlace()
+	place3.Tags = []string{"North America", "Earth"}
+	place3.Meta = map[string]string{"Piers": "Pretty Salty"}
 
 	visit1 := &TestVisit{person1.ID, place1.ID}
 	visit2 := &TestVisit{person2.ID, place2.ID}
@@ -346,6 +391,7 @@ func testPopulateData(t *testing.T, db *MemDB) {
 	noErr(t, txn.Insert("people", person3))
 	noErr(t, txn.Insert("places", place1))
 	noErr(t, txn.Insert("places", place2))
+	noErr(t, txn.Insert("places", place3))
 	noErr(t, txn.Insert("visits", visit1))
 	noErr(t, txn.Insert("visits", visit2))
 
@@ -353,7 +399,15 @@ func testPopulateData(t *testing.T, db *MemDB) {
 	txn.Commit()
 }
 
+func expectErr(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
 func noErr(t *testing.T, err error) {
+	t.Helper()
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -371,6 +425,8 @@ type TestPerson struct {
 type TestPlace struct {
 	ID   string
 	Name string
+	Tags []string
+	Meta map[string]string
 }
 
 type TestVisit struct {
@@ -428,6 +484,32 @@ func testComplexSchema() *DBSchema {
 						Name:    "name",
 						Unique:  true,
 						Indexer: &StringFieldIndex{Field: "Name"},
+					},
+					"name_tags": &IndexSchema{
+						Name:         "name_tags",
+						Unique:       true,
+						AllowMissing: true,
+						Indexer: &CompoundMultiIndex{
+							AllowMissing: true,
+							Indexes: []Indexer{
+								&StringFieldIndex{Field: "Name"},
+								&StringSliceFieldIndex{Field: "Tags"},
+							},
+						},
+					},
+					"name_tags_name_meta": &IndexSchema{
+						Name:         "name_tags_name_meta",
+						Unique:       true,
+						AllowMissing: true,
+						Indexer: &CompoundMultiIndex{
+							AllowMissing: true,
+							Indexes: []Indexer{
+								&StringFieldIndex{Field: "Name"},
+								&StringSliceFieldIndex{Field: "Tags"},
+								&StringFieldIndex{Field: "Name"},
+								&StringMapFieldIndex{Field: "Meta"},
+							},
+						},
 					},
 				},
 			},


### PR DESCRIPTION
Counterpart of StringSliceFieldIndex, with int values

This PR also includes isolated tests on a new StringSliceFieldIndex indexer (since the previous integration test schema had it inside of a CompoundMultiIndex)