### PR TITLE
Txn snapshot

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,4 @@ module github.com/hashicorp/go-memdb
 
 go 1.12
 
-require github.com/hashicorp/go-immutable-radix v1.1.0
-
-replace github.com/hashicorp/go-immutable-radix => github.com/tectonic-network/go-immutable-radix v1.0.1-0.20190916140712-d5fcbb3e4864
+require github.com/hashicorp/go-immutable-radix v1.2.0

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,5 @@ module github.com/hashicorp/go-memdb
 go 1.12
 
 require github.com/hashicorp/go-immutable-radix v1.1.0
+
+replace github.com/hashicorp/go-immutable-radix => github.com/tectonic-network/go-immutable-radix v1.0.1-0.20190916140712-d5fcbb3e4864

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
+github.com/hashicorp/go-immutable-radix v1.2.0 h1:l6UW37iCXwZkZoAbEYnptSHVE/cQ5bOTPYG5W3vf9+8=
+github.com/hashicorp/go-immutable-radix v1.2.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-uuid v1.0.0 h1:RS8zrF7PhGwyNPOtxSClXXj9HA8feRnJzgnI1RJCSnM=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/golang-lru v0.5.0 h1:CL2msUPvZTLb5O648aiLNJw3hnBxN2+1Jq8rCOH9wdo=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
-github.com/tectonic-network/go-immutable-radix v1.0.1-0.20190916140712-d5fcbb3e4864 h1:Yi5fJ6fBGlHPHRHX+E+7KB5c7RMikKH9Tuskx1aIV5E=
-github.com/tectonic-network/go-immutable-radix v1.0.1-0.20190916140712-d5fcbb3e4864/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
-github.com/hashicorp/go-immutable-radix v1.1.0 h1:vN9wG1D6KG6YHRTWr8512cxGOVgTMEfgEdSj/hr8MPc=
-github.com/hashicorp/go-immutable-radix v1.1.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-uuid v1.0.0 h1:RS8zrF7PhGwyNPOtxSClXXj9HA8feRnJzgnI1RJCSnM=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/golang-lru v0.5.0 h1:CL2msUPvZTLb5O648aiLNJw3hnBxN2+1Jq8rCOH9wdo=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/tectonic-network/go-immutable-radix v1.0.1-0.20190916140712-d5fcbb3e4864 h1:Yi5fJ6fBGlHPHRHX+E+7KB5c7RMikKH9Tuskx1aIV5E=
+github.com/tectonic-network/go-immutable-radix v1.0.1-0.20190916140712-d5fcbb3e4864/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=


### PR DESCRIPTION
This PR introduces a `Snapshot` method to `Txn`.

The new method allows to take a read-only snapshot of an open transaction.
The snapshot will survive the commit or abort of the transaction.

Depends on the feature introduced to `go-immutable-radix` by https://github.com/hashicorp/go-immutable-radix/pull/26. This PR adds a temporary `replace` directive to `go.mod` which will become unnecessary once that PR is merged.