### PR TITLE
fix: nil strings should be allowed only when AllowMissing is set

### DIFF
--- a/index.go
+++ b/index.go
@@ -73,7 +73,7 @@ func (s *StringFieldIndex) FromObject(obj interface{}) (bool, []byte, error) {
 
 	if isPtr && !fv.IsValid() {
 		val := ""
-		return true, []byte(val), nil
+		return false, []byte(val), nil
 	}
 
 	val := fv.String()

--- a/index_test.go
+++ b/index_test.go
@@ -131,8 +131,8 @@ func TestStringFieldIndex_FromObject(t *testing.T) {
 	if string(val) != "" {
 		t.Fatalf("bad: %s", val)
 	}
-	if !ok {
-		t.Fatalf("should be ok")
+	if ok {
+		t.Fatalf("should be not ok")
 	}
 }
 


### PR DESCRIPTION
This corrects a bug introduced in
97e94de6e70b3bcdd50849897f5e601e37055947.

If pointer to strings are being Indexed, a nil pointer should not result
in an error only when AllowMissing is set to true for an Index,
otherwise it should rightfully error.