### PR TITLE
Document correct usage of a ResultIterator

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -13,6 +13,10 @@ type FilterIterator struct {
 	iter ResultIterator
 }
 
+// NewFilterIterator wraps a ResultIterator. The filter function is applied
+// to each value returned from a call to wrap.Next().
+//
+// See the documentation for ResultIterator for correct usage of FilterIterator.
 func NewFilterIterator(wrap ResultIterator, filter FilterFunc) *FilterIterator {
 	return &FilterIterator{
 		filter: filter,
@@ -23,7 +27,7 @@ func NewFilterIterator(wrap ResultIterator, filter FilterFunc) *FilterIterator {
 // WatchCh returns the watch channel of the wrapped iterator.
 func (f *FilterIterator) WatchCh() <-chan struct{} { return f.iter.WatchCh() }
 
-// Next returns the next non-filtered result from the wrapped iterator
+// Next returns the next non-filtered result from the wrapped iterator.
 func (f *FilterIterator) Next() interface{} {
 	for {
 		if value := f.iter.Next(); value == nil || !f.filter(value) {


### PR DESCRIPTION
Last week we had [a panic in Consul](https://github.com/hashicorp/consul/issues/9566) that was caused by incorrect usage of a ResultIterator. A minimal reproduction of this panic can be seen [here](https://github.com/hashicorp/go-memdb/compare/panic-delete-inside-iter).

Many of us learned that there are undocumented rules for using a ResultIterator correctly with a write transaction.

This commit attempts to document that safe use of a ResultIterator.