### PR TITLE
Make ResultIteration refuse unsafe operation (option 1)

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -13,6 +13,10 @@ type FilterIterator struct {
 	iter ResultIterator
 }
 
+// NewFilterIterator wraps a ResultIterator. The filter function is applied
+// to each value returned from a call to wrap.Next().
+//
+// See the documentation for ResultIterator for correct usage of FilterIterator.
 func NewFilterIterator(wrap ResultIterator, filter FilterFunc) *FilterIterator {
 	return &FilterIterator{
 		filter: filter,
@@ -23,7 +27,7 @@ func NewFilterIterator(wrap ResultIterator, filter FilterFunc) *FilterIterator {
 // WatchCh returns the watch channel of the wrapped iterator.
 func (f *FilterIterator) WatchCh() <-chan struct{} { return f.iter.WatchCh() }
 
-// Next returns the next non-filtered result from the wrapped iterator
+// Next returns the next non-filtered result from the wrapped iterator.
 func (f *FilterIterator) Next() interface{} {
 	for {
 		if value := f.iter.Next(); value == nil || !f.filter(value) {

--- a/go.mod
+++ b/go.mod
@@ -6,3 +6,5 @@ require (
 	github.com/hashicorp/go-immutable-radix v1.3.0
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 )
+
+replace github.com/hashicorp/go-immutable-radix => github.com/hashicorp/go-immutable-radix v1.3.1-0.20210121185740-67e10d480dcf

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
-github.com/hashicorp/go-immutable-radix v1.3.0 h1:8exGP7ego3OmkfksihtSouGMZ+hQrhxx+FVELeXpVPE=
-github.com/hashicorp/go-immutable-radix v1.3.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
+github.com/hashicorp/go-immutable-radix v1.3.1-0.20210121184832-1f3613208fff h1:pCJq6LOTMatCem80dkrOG/po5/rQUM9EeIvzpcKU6mg=
+github.com/hashicorp/go-immutable-radix v1.3.1-0.20210121184832-1f3613208fff/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
+github.com/hashicorp/go-immutable-radix v1.3.1-0.20210121185740-67e10d480dcf h1:xxNhSdLiKRbDHbxlo7UkV0Jzp0NoTGSJKCvZVVBQ3fI=
+github.com/hashicorp/go-immutable-radix v1.3.1-0.20210121185740-67e10d480dcf/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-uuid v1.0.0 h1:RS8zrF7PhGwyNPOtxSClXXj9HA8feRnJzgnI1RJCSnM=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/golang-lru v0.5.0 h1:CL2msUPvZTLb5O648aiLNJw3hnBxN2+1Jq8rCOH9wdo=

--- a/txn.go
+++ b/txn.go
@@ -872,7 +872,7 @@ func (txn *Txn) getIndexIterator(table, index string, args ...interface{}) (*ira
 	indexTxn := txn.readableIndex(table, indexSchema.Name)
 	indexRoot := indexTxn.Root()
 
-	// Get an interator over the index
+	// Get an iterator over the index
 	indexIter := indexRoot.Iterator()
 	return indexIter, val, nil
 }


### PR DESCRIPTION
This is one option for making the code behave correctly in the scenario described in #85 (other options in #87, #88).

Previously this could panic anyway (see #85), but only when the nodes in an index line up in a very specify way. This meant that tests may not exercise the bug, and the panic would get into a release.

By adding an explicit panic here we ensure that any basic test coverage of an iteration with modification will fail.

In the case of inserts it would not panic, but could return incorrect results (most likely duplicate). This panic ensures we fail instead of returning incorrect results.

It would have been nice to error instead of panic, but there's no place in the current interface to return an error.

TODO:
* [ ] write another test that covers the unsafe usage that previously did not panic, but now does panic
* [ ] apply the same change to the reverse iterator