### PR TITLE
Make Insert/Delete refuse unsafe operation (option 3)

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -13,6 +13,10 @@ type FilterIterator struct {
 	iter ResultIterator
 }
 
+// NewFilterIterator wraps a ResultIterator. The filter function is applied
+// to each value returned from a call to wrap.Next().
+//
+// See the documentation for ResultIterator for correct usage of FilterIterator.
 func NewFilterIterator(wrap ResultIterator, filter FilterFunc) *FilterIterator {
 	return &FilterIterator{
 		filter: filter,
@@ -23,7 +27,7 @@ func NewFilterIterator(wrap ResultIterator, filter FilterFunc) *FilterIterator {
 // WatchCh returns the watch channel of the wrapped iterator.
 func (f *FilterIterator) WatchCh() <-chan struct{} { return f.iter.WatchCh() }
 
-// Next returns the next non-filtered result from the wrapped iterator
+// Next returns the next non-filtered result from the wrapped iterator.
 func (f *FilterIterator) Next() interface{} {
 	for {
 		if value := f.iter.Next(); value == nil || !f.filter(value) {

--- a/filter.go
+++ b/filter.go
@@ -13,6 +13,10 @@ type FilterIterator struct {
 	iter ResultIterator
 }
 
+func (f *FilterIterator) Done() {
+	f.iter.Done()
+}
+
 // NewFilterIterator wraps a ResultIterator. The filter function is applied
 // to each value returned from a call to wrap.Next().
 //

--- a/txn.go
+++ b/txn.go
@@ -872,7 +872,7 @@ func (txn *Txn) getIndexIterator(table, index string, args ...interface{}) (*ira
 	indexTxn := txn.readableIndex(table, indexSchema.Name)
 	indexRoot := indexTxn.Root()
 
-	// Get an interator over the index
+	// Get an iterator over the index
 	indexIter := indexRoot.Iterator()
 	return indexIter, val, nil
 }

--- a/txn_test.go
+++ b/txn_test.go
@@ -2215,8 +2215,11 @@ func TestTxn_GetIterAndDelete(t *testing.T) {
 	iter, err := txn.Get("main", "foo", key)
 	assertNilError(t, err)
 
-	for obj := iter.Next(); obj != nil; obj = iter.Next() {
-		assertNilError(t, txn.Delete("main", obj))
+	obj := iter.Next()
+	err = txn.Delete("main", obj)
+	expected := "operation is not safe"
+	if err == nil || !strings.Contains(err.Error(), expected) {
+		t.Fatalf("expected error with %v, got %v", expected, err)
 	}
 
 	txn.Commit()


### PR DESCRIPTION
This is one option for making the code behave correctly in the scenario described in #85 (other options in #86, #87).

Instead of a panic, make any mutation operation (Insert, Delete*) report an error if there are any iterations that have not been exhausted. This unfortunately requires a change to the interface in the rare case where an iterator is not exhausted in a for loop.

TODO:
* [ ] look for other important test cases