### PR TITLE
Fixes CompoundMultiIndex::FromObject not generating correct value combinations.

### DIFF
--- a/index.go
+++ b/index.go
@@ -821,7 +821,9 @@ forloop:
 		if depth == len(builder)-1 {
 			// These are the "leaves", so append directly
 			for _, v := range builder[depth] {
-				out = append(out, append(currPrefix, v...))
+				outcome := make([]byte, len(currPrefix))
+				copy(outcome, currPrefix)
+				out = append(out, append(outcome, v...))
 			}
 			return
 		}


### PR DESCRIPTION
This is the fix suggested in #72 and also fixes #106 which refers to the same issue.