### PR TITLE
fix(index): prevent duplicate results in CompoundMultiIndex partial key queries by removing intermediate index storage

### DIFF
--- a/index.go
+++ b/index.go
@@ -38,7 +38,7 @@ type SingleIndexer interface {
 // pointing to the same object.
 //
 // For example, an index that extracts the first and last name of a person
-// and allows lookup based on eitherd would be a MultiIndexer. The FromObject
+// and allows lookup based on either would be a MultiIndexer. The FromObject
 // of this example would split the first and last name and return both as
 // values.
 type MultiIndexer interface {
@@ -837,14 +837,20 @@ forloop:
 	}
 
 	// Start with something higher to avoid resizing if possible
-	out := make([][]byte, 0, len(c.Indexes)^3)
+	indexCount := len(c.Indexes)
+	out := make([][]byte, 0, indexCount*indexCount*indexCount)
 
-	// We are walking through the builder slice essentially in a depth-first fashion,
-	// building the prefix and leaves as we go. If AllowMissing is false, we only insert
-	// these full paths to leaves. Otherwise, we also insert each prefix along the way.
-	// This allows for lookup in FromArgs when AllowMissing is true that does not contain
-	// the full set of arguments. e.g. for {Foo, Bar} where an object has only the Foo
-	// field specified as "abc", it is valid to call FromArgs with just "abc".
+	// We walk through the builder slice in a depth-first fashion, constructing
+	// full compound index keys at the leaves. Only complete paths (leaves) are
+	// stored in the index. When AllowMissing is true and a sub-indexer returns
+	// no value, the builder will be shorter than the number of indexes, and
+	// the last collected value becomes the leaf. This allows partial compound
+	// keys to be stored for objects with missing fields.
+	//
+	// Partial key lookups (with fewer args than sub-indexes) work via the radix
+	// tree's native prefix matching (SeekPrefixWatch), not via explicit prefix
+	// storage. e.g. for {Foo, Bar} where an object has both fields, querying
+	// with just Foo will match via prefix scan of the full "FooBar" key.
 	var walkVals func([]byte, int)
 	walkVals = func(currPrefix []byte, depth int) {
 		if depth >= len(builder) {
@@ -862,9 +868,6 @@ forloop:
 		}
 		for _, v := range builder[depth] {
 			nextPrefix := append(currPrefix, v...)
-			if c.AllowMissing {
-				out = append(out, nextPrefix)
-			}
 			walkVals(nextPrefix, depth+1)
 		}
 	}

--- a/index.go
+++ b/index.go
@@ -837,8 +837,7 @@ forloop:
 	}
 
 	// Start with something higher to avoid resizing if possible
-	indexCount := len(c.Indexes)
-	out := make([][]byte, 0, indexCount*indexCount*indexCount)
+	out := make([][]byte, 0, len(c.Indexes)^3)
 
 	// We walk through the builder slice in a depth-first fashion, constructing
 	// full compound index keys at the leaves. Only complete paths (leaves) are

--- a/index_test.go
+++ b/index_test.go
@@ -1485,6 +1485,8 @@ func BenchmarkCompoundMultiIndex_FromObject(b *testing.B) {
 	}
 }
 
+// TestCompoundMultiIndex_FromObject_AllowMissing verifies that CompoundMultiIndex.FromObject
+// handles missing fields correctly based on the AllowMissing setting.
 func TestCompoundMultiIndex_FromObject_AllowMissing(t *testing.T) {
 	cases := []struct {
 		name         string
@@ -1604,6 +1606,8 @@ func TestCompoundMultiIndex_FromObject_AllowMissing(t *testing.T) {
 	}
 }
 
+// TestCompoundMultiIndex_FromArgs tests CompoundMultiIndex.FromArgs with varying
+// argument counts and validates prefix query support when AllowMissing is enabled.
 func TestCompoundMultiIndex_FromArgs(t *testing.T) {
 	cases := []struct {
 		name         string
@@ -1727,6 +1731,8 @@ func TestCompoundMultiIndex_FromArgs(t *testing.T) {
 	}
 }
 
+// valsToStrings converts a slice of byte slices to a slice of strings for
+// easier debugging and comparison in test assertions.
 func valsToStrings(vals [][]byte) []string {
 	result := make([]string, len(vals))
 	for i, v := range vals {

--- a/index_test.go
+++ b/index_test.go
@@ -1484,3 +1484,253 @@ func BenchmarkCompoundMultiIndex_FromObject(b *testing.B) {
 		}
 	}
 }
+
+func TestCompoundMultiIndex_FromObject_AllowMissing(t *testing.T) {
+	cases := []struct {
+		name         string
+		obj          *TestObject
+		indexes      []Indexer
+		allowMissing bool
+		wantOk       bool
+		wantVals     []string
+	}{
+		{
+			name: "first field missing returns empty vals",
+			obj: &TestObject{
+				ID:  "obj1",
+				Foo: "Foo1",
+				Baz: "Baz1",
+			},
+			indexes: []Indexer{
+				&StringFieldIndex{Field: "Empty"},
+				&StringFieldIndex{Field: "Foo"},
+				&StringFieldIndex{Field: "Baz"},
+			},
+			allowMissing: true,
+			wantOk:       true,
+			wantVals:     []string{},
+		},
+		{
+			name: "middle field missing produces partial key",
+			obj: &TestObject{
+				ID:  "obj1",
+				Foo: "Foo1",
+				Baz: "Baz1",
+			},
+			indexes: []Indexer{
+				&StringFieldIndex{Field: "Foo"},
+				&StringFieldIndex{Field: "Empty"},
+				&StringFieldIndex{Field: "Baz"},
+			},
+			allowMissing: true,
+			wantOk:       true,
+			wantVals:     []string{"Foo1\x00"},
+		},
+		{
+			name: "last field missing produces partial key",
+			obj: &TestObject{
+				ID:  "obj1",
+				Foo: "Foo1",
+				Baz: "Baz1",
+			},
+			indexes: []Indexer{
+				&StringFieldIndex{Field: "Foo"},
+				&StringFieldIndex{Field: "Baz"},
+				&StringFieldIndex{Field: "Empty"},
+			},
+			allowMissing: true,
+			wantOk:       true,
+			wantVals:     []string{"Foo1\x00Baz1\x00"},
+		},
+		{
+			name: "MultiIndexer before missing field produces no duplicates",
+			obj: &TestObject{
+				ID:  "obj1",
+				Qux: []string{"A", "B"},
+			},
+			indexes: []Indexer{
+				&StringSliceFieldIndex{Field: "Qux"},
+				&StringFieldIndex{Field: "Empty"},
+			},
+			allowMissing: true,
+			wantOk:       true,
+			wantVals:     []string{"A\x00", "B\x00"},
+		},
+		{
+			name: "AllowMissing false returns not ok for missing field",
+			obj: &TestObject{
+				ID:  "obj1",
+				Foo: "Foo1",
+				Baz: "Baz1",
+			},
+			indexes: []Indexer{
+				&StringFieldIndex{Field: "Foo"},
+				&StringFieldIndex{Field: "Empty"},
+				&StringFieldIndex{Field: "Baz"},
+			},
+			allowMissing: false,
+			wantOk:       false,
+			wantVals:     nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			indexer := &CompoundMultiIndex{
+				Indexes:      tc.indexes,
+				AllowMissing: tc.allowMissing,
+			}
+
+			ok, vals, err := indexer.FromObject(tc.obj)
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
+			if ok != tc.wantOk {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOk)
+			}
+
+			if tc.wantVals == nil {
+				if vals != nil {
+					t.Fatalf("vals should be nil, got %v", vals)
+				}
+				return
+			}
+
+			got := valsToStrings(vals)
+			if !reflect.DeepEqual(got, tc.wantVals) {
+				t.Fatalf("\ngot:  %v\nwant: %v", got, tc.wantVals)
+			}
+		})
+	}
+}
+
+func TestCompoundMultiIndex_FromArgs(t *testing.T) {
+	cases := []struct {
+		name         string
+		allowMissing bool
+		args         []any
+		wantErr      bool
+		wantValue    string
+	}{
+		{
+			name:         "AllowMissing=false no args returns error",
+			allowMissing: false,
+			args:         []any{},
+			wantErr:      true,
+		},
+		{
+			name:         "AllowMissing=false partial args returns error",
+			allowMissing: false,
+			args:         []any{"foo", "bar"},
+			wantErr:      true,
+		},
+		{
+			name:         "AllowMissing=false too many args returns error",
+			allowMissing: false,
+			args:         []any{"foo", "bar", "baz", "extra"},
+			wantErr:      true,
+		},
+		{
+			name:         "AllowMissing=false wrong type returns error",
+			allowMissing: false,
+			args:         []any{42, "bar", "baz"},
+			wantErr:      true,
+		},
+		{
+			name:         "AllowMissing=false nil arg returns error",
+			allowMissing: false,
+			args:         []any{"foo", nil, "baz"},
+			wantErr:      true,
+		},
+		{
+			name:         "AllowMissing=false correct args returns compound key",
+			allowMissing: false,
+			args:         []any{"foo", "bar", "baz"},
+			wantErr:      false,
+			wantValue:    "foo\x00bar\x00baz\x00",
+		},
+		{
+			name:         "AllowMissing=false empty string arg succeeds",
+			allowMissing: false,
+			args:         []any{"", "bar", "baz"},
+			wantErr:      false,
+			wantValue:    "\x00bar\x00baz\x00",
+		},
+		{
+			name:         "AllowMissing=true no args returns empty key",
+			allowMissing: true,
+			args:         []any{},
+			wantErr:      false,
+			wantValue:    "",
+		},
+		{
+			name:         "AllowMissing=true one of three args succeeds",
+			allowMissing: true,
+			args:         []any{"foo"},
+			wantErr:      false,
+			wantValue:    "foo\x00",
+		},
+		{
+			name:         "AllowMissing=true two of three args succeeds",
+			allowMissing: true,
+			args:         []any{"foo", "bar"},
+			wantErr:      false,
+			wantValue:    "foo\x00bar\x00",
+		},
+		{
+			name:         "AllowMissing=true full args succeeds",
+			allowMissing: true,
+			args:         []any{"foo", "bar", "baz"},
+			wantErr:      false,
+			wantValue:    "foo\x00bar\x00baz\x00",
+		},
+		{
+			name:         "AllowMissing=true too many args returns error",
+			allowMissing: true,
+			args:         []any{"foo", "bar", "baz", "extra"},
+			wantErr:      true,
+		},
+		{
+			name:         "AllowMissing=true empty string arg succeeds",
+			allowMissing: true,
+			args:         []any{"foo", "", "baz"},
+			wantErr:      false,
+			wantValue:    "foo\x00\x00baz\x00",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			indexer := &CompoundMultiIndex{
+				Indexes: []Indexer{
+					&StringFieldIndex{Field: "Foo"},
+					&StringFieldIndex{Field: "Bar"},
+					&StringFieldIndex{Field: "Baz"},
+				},
+				AllowMissing: tc.allowMissing,
+			}
+
+			val, err := indexer.FromArgs(tc.args...)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
+			if got := string(val); got != tc.wantValue {
+				t.Fatalf("got %q, want %q", got, tc.wantValue)
+			}
+		})
+	}
+}
+
+func valsToStrings(vals [][]byte) []string {
+	result := make([]string, len(vals))
+	for i, v := range vals {
+		result[i] = string(v)
+	}
+	return result
+}

--- a/integ_test.go
+++ b/integ_test.go
@@ -282,6 +282,34 @@ func TestComplexDB(t *testing.T) {
 	if place.Tags[1] != "Earth" {
 		t.Fatalf("bad place: %v", place)
 	}
+
+	iter, err := txn.Get("people", "last_first", "Dadgar")
+	noErr(t, err)
+	peopleByID := make(map[string]*TestPerson)
+	for obj := iter.Next(); obj != nil; obj = iter.Next() {
+		p := obj.(*TestPerson)
+		if _, exists := peopleByID[p.ID]; exists {
+			t.Fatalf("duplicate result for person ID %s", p.ID)
+		}
+		peopleByID[p.ID] = p
+	}
+	if len(peopleByID) != 2 {
+		t.Fatalf("expected 2 results with Last=Dadgar, got %d", len(peopleByID))
+	}
+
+	iter, err = txn.Get("places", "name_tags", "Maui")
+	noErr(t, err)
+	var mauiCount int
+	for obj := iter.Next(); obj != nil; obj = iter.Next() {
+		p := obj.(*TestPlace)
+		if p.Name != "Maui" {
+			t.Fatalf("expected Maui, got %s", p.Name)
+		}
+		mauiCount++
+	}
+	if mauiCount != 1 {
+		t.Fatalf("expected 1 Maui place with missing tags, got %d", mauiCount)
+	}
 }
 
 func TestWatchUpdate(t *testing.T) {
@@ -472,6 +500,17 @@ func testComplexSchema() *DBSchema {
 						Name:    "sibling",
 						Unique:  false,
 						Indexer: &FieldSetIndex{Field: "Sibling"},
+					},
+					"last_first": &IndexSchema{
+						Name:         "last_first",
+						AllowMissing: true,
+						Indexer: &CompoundMultiIndex{
+							AllowMissing: true,
+							Indexes: []Indexer{
+								&StringFieldIndex{Field: "Last"},
+								&StringFieldIndex{Field: "First"},
+							},
+						},
 					},
 				},
 			},


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Description
CompoundMultiIndex was returning duplicate objects when queried with partial keys (i.e. a number of arguments lower than the number of indexed fields) and AllowMissing was set to `true`.

When `AllowMissing` was `true`, `CompoundMultiIndex.FromObject()` stored both intermediate prefixes and full compound keys in the index. This caused duplicate results when querying with partial keys, as the radix tree's `SeekPrefixWatch` matched both the explicit prefix entries and the full key. We believe that this behaviour was not intentional and is a bug.

The fix removes intermediate prefix storage. Partial key queries continue to work via the radix tree's native prefix matching, and objects with missing index fields are still indexed correctly using their partial compound keys.

<!-- Provide a summary of what the PR does and why it is being submitted. -->

## Related Issue
- https://github.com/hashicorp/go-memdb/issues/95 
- VAULT-41844
<!-- If this PR is linked to any issue, provide the issue number or description here. Any related JIRA tickets can also be added here. -->

## How Has This Been Tested?
New unit tests for the `CompoundMultiIndex` have been added, together with additional test cases in the `TestComplexDB` integration test. All of the pre-existing test cases are still passing.
<!-- Describe how the changes have been tested. Provide test instructions or details. -->
