### PR TITLE
fix(index): calculate the exact output slice capacity preallocation in CompoundMultiIndex.FromObject

### DIFF
--- a/index.go
+++ b/index.go
@@ -836,8 +836,8 @@ forloop:
 		}
 	}
 
-	// Start with something higher to avoid resizing if possible
-	out := make([][]byte, 0, len(c.Indexes)^3)
+	// Allocate output slice with exact capacity for all index combinations.
+	out := make([][]byte, 0, indexCombinationCount(builder))
 
 	// We are walking through the builder slice essentially in a depth-first fashion,
 	// building the prefix and leaves as we go. If AllowMissing is false, we only insert
@@ -931,4 +931,18 @@ func (c *CompoundMultiIndex) FromArgs(args ...interface{}) ([]byte, error) {
 		out = append(out, val...)
 	}
 	return out, nil
+}
+
+// indexCombinationCount returns the total number of index key combinations
+// that will be generated from the builder slice. This is the product of
+// the lengths of each entry in the builder.
+func indexCombinationCount(builder [][][]byte) int {
+	if len(builder) == 0 {
+		return 0
+	}
+	count := 1
+	for _, vals := range builder {
+		count *= len(vals)
+	}
+	return count
 }

--- a/index_test.go
+++ b/index_test.go
@@ -1485,6 +1485,8 @@ func BenchmarkCompoundMultiIndex_FromObject(b *testing.B) {
 	}
 }
 
+// TestIndexCombinationCount verifies that indexCombinationCount correctly
+// computes the product of index value slice lengths.
 func TestIndexCombinationCount(t *testing.T) {
 	cases := []struct {
 		name     string

--- a/index_test.go
+++ b/index_test.go
@@ -1484,3 +1484,46 @@ func BenchmarkCompoundMultiIndex_FromObject(b *testing.B) {
 		}
 	}
 }
+
+func TestIndexCombinationCount(t *testing.T) {
+	cases := []struct {
+		name     string
+		builder  [][][]byte
+		expected int
+	}{
+		{
+			name:     "empty builder",
+			builder:  [][][]byte{},
+			expected: 0,
+		},
+		{
+			name:     "single entry with 1 value",
+			builder:  [][][]byte{{{1}}},
+			expected: 1,
+		},
+		{
+			name:     "single entry with 3 values",
+			builder:  [][][]byte{{{1}, {2}, {3}}},
+			expected: 3,
+		},
+		{
+			name:     "two entries: 2 * 3 = 6",
+			builder:  [][][]byte{{{1}, {2}}, {{3}, {4}, {5}}},
+			expected: 6,
+		},
+		{
+			name:     "three entries: 2 * 3 * 4 = 24",
+			builder:  [][][]byte{{{1}, {2}}, {{3}, {4}, {5}}, {{6}, {7}, {8}, {9}}},
+			expected: 24,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := indexCombinationCount(tc.builder)
+			if got != tc.expected {
+				t.Errorf("got %d, want %d", got, tc.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Description

I stumbled upon this bug while working on fixing a different issue in `CompoundMultiIndex.FromObject()`.

The output slice capacity in `CompoundMultiIndex.FromObject()` was preallocated using `len(c.Indexes)^3`, which:

1. Uses a XOR operator instead of exponentiation.
2. Doesn't reflect the actual number of combinations generated.

This PR replaces that heuristic with an exact calculation: the product of the lengths of each index value slice. This is done inside of a helper function (`indexCombinationCount`) so that we can unit-test the fix.

<!-- Provide a summary of what the PR does and why it is being submitted. -->

## Related Issue

<!-- If this PR is linked to any issue, provide the issue number or description here. Any related JIRA tickets can also be added here. -->

## How Has This Been Tested?

A brand new and shiny unit test (`TestIndexCombinationCount`).

<!-- Describe how the changes have been tested. Provide test instructions or details. -->
