### PR TITLE
Introducing Count for Index column values

### DIFF
--- a/memdb.go
+++ b/memdb.go
@@ -117,3 +117,21 @@ func (db *MemDB) initialize() error {
 func indexPath(table, index string) []byte {
 	return []byte(table + "." + index)
 }
+
+// Count returns the number of elements in the given table's index.
+func (db *MemDB) Count(table, index string) int {
+	root := db.getRoot()
+	path := indexPath(table, index)
+	raw, _ := root.Get(path)
+
+	if raw == nil {
+		return 0
+	}
+
+	idxTree, ok := raw.(*iradix.Tree)
+	if !ok {
+		return 0
+	}
+
+	return idxTree.Len()
+}

--- a/memdb_test.go
+++ b/memdb_test.go
@@ -86,3 +86,113 @@ func TestMemDB_Snapshot(t *testing.T) {
 		t.Fatalf("should exist")
 	}
 }
+
+func TestMemDB_SimpleCount(t *testing.T) {
+	db, err := NewMemDB(testValidSchema())
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	txn := db.Txn(true)
+
+	obj1 := &TestObject{
+		ID:  "a",
+		Foo: "xyz",
+		Qux: []string{"xyz1"},
+	}
+	obj2 := &TestObject{
+		ID:  "medium-length",
+		Foo: "xyz",
+		Qux: []string{"xyz1", "xyz2"},
+	}
+	obj3 := &TestObject{
+		ID:  "super-long-unique-identifier",
+		Foo: "xyz",
+		Qux: []string{"xyz1", "xyz2"},
+		Bar: 2,
+	}
+
+	// Pre-insert counts should be zero
+	if count := db.Count("main", "id"); count != 0 {
+		t.Fatalf("bad count: %d", count)
+	}
+
+	if count := db.Count("main", "foo"); count != 0 {
+		t.Fatalf("bad count: %d", count)
+	}
+
+	if count := db.Count("main", "qux"); count != 0 {
+		t.Fatalf("bad count: %d", count)
+	}
+
+	err = txn.Insert("main", obj1)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Pre-commit counts should be zero
+	if count := db.Count("main", "id"); count != 0 {
+		t.Fatalf("bad count: %d", count)
+	}
+
+	if count := db.Count("main", "foo"); count != 0 {
+		t.Fatalf("bad count: %d", count)
+	}
+
+	if count := db.Count("main", "qux"); count != 0 {
+		t.Fatalf("bad count: %d", count)
+	}
+
+	err = txn.Insert("main", obj2)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	txn.Commit()
+
+	// Post-commit counts should reflect the two inserted objects
+	if count := db.Count("main", "id"); count != 2 {
+		t.Fatalf("bad count: %d", count)
+	}
+
+	if count := db.Count("main", "foo"); count != 2 {
+		t.Fatalf("bad count: %d", count)
+	}
+
+	// The "qux" index should have 3 entries because obj2 has two values in the "qux" field
+	if count := db.Count("main", "qux"); count != 3 {
+		t.Fatalf("bad count: %d", count)
+	}
+
+	txn = db.Txn(true)
+	err = txn.Insert("main", obj3)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	txn.Commit()
+
+	txn = db.Txn(false)
+	defer txn.Abort()
+
+	if count := db.Count("main", "id"); count != 3 {
+		t.Fatalf("bad count: %d", count)
+	}
+
+	if count := db.Count("main", "foo"); count != 3 {
+		t.Fatalf("bad count: %d", count)
+	}
+
+	if count := db.Count("main", "qux"); count != 5 {
+		t.Fatalf("bad count: %d", count)
+	}
+
+	// non-index column not supported by Count and will return 0
+	if count := db.Count("main", "bar"); count != 0 {
+		t.Fatalf("bad count: %d", count)
+	}
+
+	// non-existent column not supported by Count and will return 0
+	if count := db.Count("main", "bazooka"); count != 0 {
+		t.Fatalf("bad count: %d", count)
+	}
+}


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Description

Introduces a Count function to efficiently return index column values using underlying immutable-radix tree's Len() function.

## Related Issue

[Add an efficient Count method to find the number of items in each index.](https://github.com/hashicorp/go-memdb/issues/83)

## How Has This Been Tested?

Test TestMemDB_SimpleCount added in memdb_test.go
