### PR TITLE
fix: correct typo "seperate" → "separate" in MultiIndexer comment

### DIFF
--- a/index.go
+++ b/index.go
@@ -34,7 +34,7 @@ type SingleIndexer interface {
 }
 
 // MultiIndexer is an interface used for defining indexes that generate
-// multiple values per object. Each value is stored as a seperate index
+// multiple values per object. Each value is stored as a separate index
 // pointing to the same object.
 //
 // For example, an index that extracts the first and last name of a person


### PR DESCRIPTION
## Summary

Fixes a typo in the `MultiIndexer` interface doc comment in `index.go`: \"seperate index\" → \"separate index\". Comment-only fix, no behavior change.

DCO signed-off-by included per HashiCorp contributor convention.